### PR TITLE
manifest: label {,u}mount as `install_exec_t` to avoid selinux denials

### DIFF
--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -109,6 +109,10 @@ func (p *Build) getSELinuxLabels() map[string]string {
 		switch pkg.Name {
 		case "coreutils":
 			labels["/usr/bin/cp"] = "system_u:object_r:install_exec_t:s0"
+			// TODO: make this conditional on something? it is
+			// only needed for "osbuild-deploy-container"
+			labels["/usr/bin/mount"] = "system_u:object_r:install_exec_t:s0"
+			labels["/usr/bin/umount"] = "system_u:object_r:install_exec_t:s0"
 		case "tar":
 			labels["/usr/bin/tar"] = "system_u:object_r:install_exec_t:s0"
 		}


### PR DESCRIPTION
I explored the ideas around how to make `osbuild-deploy-container` selinux denial free a bit Friday/Monday and here is one way of doing it that avoids us having to implement a native ctypes based mount/unmount. Please double check my reasoning below @ondrejbudai and @achilleas-k 

---
When running osbuild inside a container created via the new `osbuild-deploy-container` the selinux setup is interesting (and different from a normal host).

Because the `/` inside the contains is mounted `nosuid` the main osbuild binary is labeled with `install_exec_t` because with `nosuid` the transition from `osbuild_t` to `install_t` is not allowed. This works around the limitations of the container.

However when in `install_t` the transition to `mount_t` is not allowed which leads to an selinux denial in the logs. The `install_t` has all the privs needed so even with this transition failing mount still works.

This commit labels `{,u}mount` with `install_exec_t` in the buildroot now as well to avoid this error in the logs.

Open questions:
- is this *really* strictly only for the buildroot or could these hacked permissions somehow escape into a real image?
- why is the error from `install_t` -> `mount_t` not fatal?

Missing:
- some sort of integration test that ensures we can automatically test that the contains is free of denials.