### PR TITLE
otk-gen-partition-table: cleanups/small refactor

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -14,26 +14,26 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type OtkGenPartitionInput struct {
-	Options    *OtkPartOptions `json:"options"`
-	Partitions []*OtkPartition `json:"partitions"`
+type OtkPartInput struct {
+	Options    *OtkPartInputOptions     `json:"options"`
+	Partitions []*OtkPartInputPartition `json:"partitions"`
 }
 
-type OtkPartOptions struct {
-	UEFI *OtkPartUEFI `json:"uefi"`
-	BIOS bool         `json:"bios"`
-	Type string       `json:"type"`
-	Size string       `json:"size"`
-	UUID string       `json:"uuid"`
+type OtkPartInputOptions struct {
+	UEFI *OtkPartInputUEFI `json:"uefi"`
+	BIOS bool              `json:"bios"`
+	Type string            `json:"type"`
+	Size string            `json:"size"`
+	UUID string            `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
 
-type OtkPartUEFI struct {
+type OtkPartInputUEFI struct {
 	Size string `json:"size"`
 }
 
-type OtkPartition struct {
+type OtkPartInputPartition struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
 	Label      string `json:"label"`
@@ -47,32 +47,31 @@ type OtkPartition struct {
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 }
 
-// XXX: review all struct names and make them consistent (OtkOutput*?)
-type OtkGenPartitionsOutput struct {
-	Const OtkGenPartConstOutput `json:"const"`
+type OtkPartOutput struct {
+	Const OtkPartOutputConst `json:"const"`
 }
 
-type OtkGenPartitionsInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
+type OtkPartOutputConst struct {
+	KernelOptsList []string `json:"kernel_opts_list"`
+	// we generate this for convenience for otk users, so that they
+	// can write, e.g. "filesystem.partition_map.boot.uuid"
+	PartitionMap map[string]OtkPartOutputPartition `json:"partition_map"`
+	Internal     OtkPartOutputInternal             `json:"internal"`
 }
 
 // "exported" view of partitions, this is an API so only add things here
 // that are really needed and unlikely to change
-type OtkPublicPartition struct {
+type OtkPartOutputPartition struct {
 	// not a UUID type because fat UUIDs are not compliant
 	UUID string `json:"uuid"`
 }
 
-type OtkGenPartConstOutput struct {
-	KernelOptsList []string `json:"kernel_opts_list"`
-	// we generate this for convenience for otk users, so that they
-	// can write, e.g. "filesystem.partition_map.boot.uuid"
-	PartitionMap map[string]OtkPublicPartition `json:"partition_map"`
-	Internal     OtkGenPartitionsInternal      `json:"internal"`
+type OtkPartOutputInternal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
 }
 
-func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
-	pm := make(map[string]OtkPublicPartition, len(pt.Partitions))
+func makePartMap(pt *disk.PartitionTable) map[string]OtkPartOutputPartition {
+	pm := make(map[string]OtkPartOutputPartition, len(pt.Partitions))
 	// TODO: think about exposing more partitions, if we do, what labels
 	// would we use? OtkPartition.Name? what about clashes with
 	// "{r,b}oot" then?
@@ -81,11 +80,11 @@ func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
 		case *disk.Filesystem:
 			switch pl.Mountpoint {
 			case "/":
-				pm["root"] = OtkPublicPartition{
+				pm["root"] = OtkPartOutputPartition{
 					UUID: pl.UUID,
 				}
 			case "/boot":
-				pm["boot"] = OtkPublicPartition{
+				pm["boot"] = OtkPartOutputPartition{
 					UUID: pl.UUID,
 				}
 			}
@@ -95,7 +94,7 @@ func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
 	return pm
 }
 
-func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.PartitionTable, error) {
+func makePartitionTableFromOtkInput(input *OtkPartInput) (*disk.PartitionTable, error) {
 	pt := &disk.PartitionTable{
 		UUID:       input.Options.UUID,
 		Type:       input.Options.Type,
@@ -161,7 +160,7 @@ func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.Partitio
 // Missing:
 // 1. customizations^Wmodifications, e.g. extra partiton tables
 // 2. refactor, make this nicer, it sucks a bit right now
-func genPartitionTable(genPartInput *OtkGenPartitionInput, rng *rand.Rand) (*OtkGenPartitionsOutput, error) {
+func genPartitionTable(genPartInput *OtkPartInput, rng *rand.Rand) (*OtkPartOutput, error) {
 	basePt, err := makePartitionTableFromOtkInput(genPartInput)
 	if err != nil {
 		return nil, err
@@ -173,9 +172,9 @@ func genPartitionTable(genPartInput *OtkGenPartitionInput, rng *rand.Rand) (*Otk
 	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
-	otkPart := &OtkGenPartitionsOutput{
-		Const: OtkGenPartConstOutput{
-			Internal: OtkGenPartitionsInternal{
+	otkPart := &OtkPartOutput{
+		Const: OtkPartOutputConst{
+			Internal: OtkPartOutputInternal{
 				PartitionTable: pt,
 			},
 			KernelOptsList: kernelOptions,
@@ -195,7 +194,7 @@ func run(r io.Reader, w io.Writer) error {
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(rngSeed))
 
-	var genPartInput OtkGenPartitionInput
+	var genPartInput OtkPartInput
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return err
 	}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -14,26 +14,26 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type OtkPartInput struct {
-	Options    *OtkPartInputOptions     `json:"options"`
-	Partitions []*OtkPartInputPartition `json:"partitions"`
+type Input struct {
+	Options    *InputOptions     `json:"options"`
+	Partitions []*InputPartition `json:"partitions"`
 }
 
-type OtkPartInputOptions struct {
-	UEFI *OtkPartInputUEFI `json:"uefi"`
-	BIOS bool              `json:"bios"`
-	Type string            `json:"type"`
-	Size string            `json:"size"`
-	UUID string            `json:"uuid"`
+type InputOptions struct {
+	UEFI *InputUEFI `json:"uefi"`
+	BIOS bool       `json:"bios"`
+	Type string     `json:"type"`
+	Size string     `json:"size"`
+	UUID string     `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
 
-type OtkPartInputUEFI struct {
+type InputUEFI struct {
 	Size string `json:"size"`
 }
 
-type OtkPartInputPartition struct {
+type InputPartition struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
 	Label      string `json:"label"`
@@ -47,44 +47,44 @@ type OtkPartInputPartition struct {
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 }
 
-type OtkPartOutput struct {
-	Const OtkPartOutputConst `json:"const"`
+type Output struct {
+	Const OutputConst `json:"const"`
 }
 
-type OtkPartOutputConst struct {
+type OutputConst struct {
 	KernelOptsList []string `json:"kernel_opts_list"`
 	// we generate this for convenience for otk users, so that they
 	// can write, e.g. "filesystem.partition_map.boot.uuid"
-	PartitionMap map[string]OtkPartOutputPartition `json:"partition_map"`
-	Internal     OtkPartOutputInternal             `json:"internal"`
+	PartitionMap map[string]OutputPartition `json:"partition_map"`
+	Internal     OutputInternal             `json:"internal"`
 }
 
 // "exported" view of partitions, this is an API so only add things here
 // that are really needed and unlikely to change
-type OtkPartOutputPartition struct {
+type OutputPartition struct {
 	// not a UUID type because fat UUIDs are not compliant
 	UUID string `json:"uuid"`
 }
 
-type OtkPartOutputInternal struct {
+type OutputInternal struct {
 	PartitionTable *disk.PartitionTable `json:"partition-table"`
 }
 
-func makePartMap(pt *disk.PartitionTable) map[string]OtkPartOutputPartition {
-	pm := make(map[string]OtkPartOutputPartition, len(pt.Partitions))
+func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
+	pm := make(map[string]OutputPartition, len(pt.Partitions))
 	// TODO: think about exposing more partitions, if we do, what labels
-	// would we use? OtkPartition.Name? what about clashes with
+	// would we use? ition.Name? what about clashes with
 	// "{r,b}oot" then?
 	for _, part := range pt.Partitions {
 		switch pl := part.Payload.(type) {
 		case *disk.Filesystem:
 			switch pl.Mountpoint {
 			case "/":
-				pm["root"] = OtkPartOutputPartition{
+				pm["root"] = OutputPartition{
 					UUID: pl.UUID,
 				}
 			case "/boot":
-				pm["boot"] = OtkPartOutputPartition{
+				pm["boot"] = OutputPartition{
 					UUID: pl.UUID,
 				}
 			}
@@ -94,7 +94,7 @@ func makePartMap(pt *disk.PartitionTable) map[string]OtkPartOutputPartition {
 	return pm
 }
 
-func makePartitionTableFromOtkInput(input *OtkPartInput) (*disk.PartitionTable, error) {
+func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) {
 	pt := &disk.PartitionTable{
 		UUID:       input.Options.UUID,
 		Type:       input.Options.Type,
@@ -160,7 +160,7 @@ func makePartitionTableFromOtkInput(input *OtkPartInput) (*disk.PartitionTable, 
 // Missing:
 // 1. customizations^Wmodifications, e.g. extra partiton tables
 // 2. refactor, make this nicer, it sucks a bit right now
-func genPartitionTable(genPartInput *OtkPartInput, rng *rand.Rand) (*OtkPartOutput, error) {
+func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	basePt, err := makePartitionTableFromOtkInput(genPartInput)
 	if err != nil {
 		return nil, err
@@ -172,9 +172,9 @@ func genPartitionTable(genPartInput *OtkPartInput, rng *rand.Rand) (*OtkPartOutp
 	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
-	otkPart := &OtkPartOutput{
-		Const: OtkPartOutputConst{
-			Internal: OtkPartOutputInternal{
+	otkPart := &Output{
+		Const: OutputConst{
+			Internal: OutputInternal{
 				PartitionTable: pt,
 			},
 			KernelOptsList: kernelOptions,
@@ -194,7 +194,7 @@ func run(r io.Reader, w io.Writer) error {
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(rngSeed))
 
-	var genPartInput OtkPartInput
+	var genPartInput Input
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return err
 	}

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-var expectedInput = &genpart.OtkPartInput{
-	Options: &genpart.OtkPartInputOptions{
-		UEFI: &genpart.OtkPartInputUEFI{
+var expectedInput = &genpart.Input{
+	Options: &genpart.InputOptions{
+		UEFI: &genpart.InputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
 		Type: "gpt",
 		Size: "10 GiB",
 	},
-	Partitions: []*genpart.OtkPartInputPartition{
+	Partitions: []*genpart.InputPartition{
 		{
 			Name:       "root",
 			Mountpoint: "/",
@@ -38,22 +38,22 @@ var expectedInput = &genpart.OtkPartInput{
 }
 
 func TestUnmarshalInput(t *testing.T) {
-	var otkInput genpart.OtkPartInput
+	var otkInput genpart.Input
 	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.OtkPartOutput{
-		Const: genpart.OtkPartOutputConst{
+	fakeOtkOutput := &genpart.Output{
+		Const: genpart.OutputConst{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OtkPartOutputPartition{
+			PartitionMap: map[string]genpart.OutputPartition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OtkPartOutputInternal{
+			Internal: genpart.OutputInternal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-var expectedInput = &genpart.OtkGenPartitionInput{
-	Options: &genpart.OtkPartOptions{
-		UEFI: &genpart.OtkPartUEFI{
+var expectedInput = &genpart.OtkPartInput{
+	Options: &genpart.OtkPartInputOptions{
+		UEFI: &genpart.OtkPartInputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
 		Type: "gpt",
 		Size: "10 GiB",
 	},
-	Partitions: []*genpart.OtkPartition{
+	Partitions: []*genpart.OtkPartInputPartition{
 		{
 			Name:       "root",
 			Mountpoint: "/",
@@ -38,22 +38,22 @@ var expectedInput = &genpart.OtkGenPartitionInput{
 }
 
 func TestUnmarshalInput(t *testing.T) {
-	var otkInput genpart.OtkGenPartitionInput
+	var otkInput genpart.OtkPartInput
 	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.OtkGenPartitionsOutput{
-		Const: genpart.OtkGenPartConstOutput{
+	fakeOtkOutput := &genpart.OtkPartOutput{
+		Const: genpart.OtkPartOutputConst{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OtkPublicPartition{
+			PartitionMap: map[string]genpart.OtkPartOutputPartition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OtkGenPartitionsInternal{
+			Internal: genpart.OtkPartOutputInternal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{
@@ -226,68 +226,6 @@ var expectedSimplePartOutput = `{
   }
 }
 `
-
-var expectedOutput = &genpart.OtkGenPartitionsOutput{
-	Const: genpart.OtkGenPartConstOutput{
-		KernelOptsList: []string{},
-		PartitionMap: map[string]genpart.OtkPublicPartition{
-			"root": {
-				UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-			},
-		},
-		Internal: genpart.OtkGenPartitionsInternal{
-			PartitionTable: &disk.PartitionTable{
-				Size: 10740563968,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Type: "gpt",
-				Partitions: []disk.Partition{
-					{
-						Start:    1048576,
-						Size:     1048576,
-						Type:     "21686148-6449-6E6F-744E-656564454649",
-						Bootable: true,
-						UUID:     "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
-					}, {
-						Start:    2097152,
-						Size:     1073741824,
-						Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-						Bootable: false,
-						UUID:     "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
-						Payload: &disk.Filesystem{
-							Type:         "vfat",
-							UUID:         "7B77-95E7",
-							Label:        "EFI-SYSTEM",
-							Mountpoint:   "/boot/efi",
-							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-							FSTabFreq:    0,
-							FSTabPassNo:  2,
-						},
-					}, {
-						Start: 3223322624,
-						Size:  7517224448,
-						UUID:  "a178892e-e285-4ce1-9114-55780875d64e",
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-							Label:      "root",
-							Mountpoint: "/",
-						},
-					}, {
-						Start: 1075838976,
-						Size:  2147483648,
-						UUID:  "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
-							Label:      "home",
-							Mountpoint: "/home",
-						},
-					},
-				},
-			},
-		},
-	},
-}
 
 func TestIntegration(t *testing.T) {
 	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,7 +81,7 @@ func TestUnmarshalOutput(t *testing.T) {
       }
     },
     "internal": {
-      "internal-partition-table": {
+      "partition-table": {
         "Size": 911,
         "UUID": "",
         "Type": "",
@@ -143,6 +142,88 @@ var simplePartOptions = `
       "type": "ext4"
     }
   ]
+}
+`
+
+// XXX: anything under "internal" we don't actually need to test
+// as we do not make any gurantees to the outside
+var expectedSimplePartOutput = `{
+  "const": {
+    "kernel_opts_list": [],
+    "partition_map": {
+      "root": {
+        "uuid": "9851898e-0b30-437d-8fad-51ec16c3697f"
+      }
+    },
+    "internal": {
+      "partition-table": {
+        "Size": 10740563968,
+        "UUID": "dbd21911-1c4e-4107-8a9f-14fe6e751358",
+        "Type": "gpt",
+        "Partitions": [
+          {
+            "Start": 1048576,
+            "Size": 1048576,
+            "Type": "21686148-6449-6E6F-744E-656564454649",
+            "Bootable": true,
+            "UUID": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+            "Payload": null
+          },
+          {
+            "Start": 2097152,
+            "Size": 1073741824,
+            "Type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "Bootable": false,
+            "UUID": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+            "Payload": {
+              "Type": "vfat",
+              "UUID": "7B77-95E7",
+              "Label": "EFI-SYSTEM",
+              "Mountpoint": "/boot/efi",
+              "FSTabOptions": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 2
+            }
+          },
+          {
+            "Start": 3223322624,
+            "Size": 7517224448,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "ed130be6-c822-49af-83bb-4ea648bb2264",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "9851898e-0b30-437d-8fad-51ec16c3697f",
+              "Label": "root",
+              "Mountpoint": "/",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            }
+          },
+          {
+            "Start": 1075838976,
+            "Size": 2147483648,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "9f6173fd-edc9-4dbe-9313-632af556c607",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "d8bb61b8-81cf-4c85-937b-69439a23dc5e",
+              "Label": "home",
+              "Mountpoint": "/home",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            }
+          }
+        ],
+        "SectorSize": 0,
+        "ExtraPadding": 0,
+        "StartOffset": 0
+      }
+    }
+  }
 }
 `
 
@@ -209,10 +290,11 @@ var expectedOutput = &genpart.OtkGenPartitionsOutput{
 }
 
 func TestIntegration(t *testing.T) {
-	rng := rand.New(rand.NewSource(0))
+	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")
 
-	buf := bytes.NewBufferString(simplePartOptions)
-	otkOutputs, err := genpart.Run(buf, rng)
+	inp := bytes.NewBufferString(simplePartOptions)
+	outp := bytes.NewBuffer(nil)
+	err := genpart.Run(inp, outp)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedOutput, otkOutputs)
+	assert.Equal(t, expectedSimplePartOutput, outp.String())
 }


### PR DESCRIPTION
otk-gen-partition-table: cleanup struct names

The struct names for the inputs/outputs of the otk-gen-partition-table
are not very conistent. This commit changes this so that there
is (a bit) more structure and symetry.

---

otk-gen-partition-table: extract genPartitionTable() from
 run()

Make run() do the scaffolding like reading from stdin/outputing to
stdout and extract a helper `genPartitionTable()` that does the
work with real structures.
