### PR TITLE
otk-gen-partition-table: add "modification" to tweak image

### DIFF
--- a/cmd/otk-gen-partition-table/export_test.go
+++ b/cmd/otk-gen-partition-table/export_test.go
@@ -1,3 +1,6 @@
 package main
 
-var Run = run
+var (
+	Run               = run
+	GenPartitionTable = genPartitionTable
+)

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -10,21 +10,24 @@ import (
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
 type Input struct {
-	Options    *InputOptions     `json:"options"`
+	Options    InputOptions      `json:"options"`
 	Partitions []*InputPartition `json:"partitions"`
+
+	Modifications InputModifications `json:"modifications"`
 }
 
 type InputOptions struct {
-	UEFI *InputUEFI `json:"uefi"`
-	BIOS bool       `json:"bios"`
-	Type string     `json:"type"`
-	Size string     `json:"size"`
-	UUID string     `json:"uuid"`
+	UEFI InputUEFI `json:"uefi"`
+	BIOS bool      `json:"bios"`
+	Type string    `json:"type"`
+	Size string    `json:"size"`
+	UUID string    `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
@@ -45,6 +48,11 @@ type InputPartition struct {
 	FSPassNo   uint64 `json:"fs_passno"`
 
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+}
+
+type InputModifications struct {
+	PartitionMode disk.PartitioningMode               `json:"partition_mode"`
+	Filesystems   []blueprint.FilesystemCustomization `json:"filesystems"`
 }
 
 type Output struct {
@@ -157,16 +165,12 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 	return pt, nil
 }
 
-// Missing:
-// 1. customizations^Wmodifications, e.g. extra partiton tables
-// 2. refactor, make this nicer, it sucks a bit right now
 func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	basePt, err := makePartitionTableFromOtkInput(genPartInput)
 	if err != nil {
 		return nil, err
 	}
-
-	pt, err := disk.NewPartitionTable(basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(basePt, genPartInput.Modifications.Filesystems, 0, genPartInput.Modifications.PartitionMode, nil, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -198,6 +202,9 @@ func run(r io.Reader, w io.Writer) error {
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return err
 	}
+	// XXX: validate inputs, right now an empty "type" is not an error
+	// but it should either be an error or we should set a default
+
 	output, err := genPartitionTable(&genPartInput, rng)
 	if err != nil {
 		return fmt.Errorf("cannot generate partition table: %w", err)

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -16,13 +16,13 @@ import (
 )
 
 type Input struct {
-	Options    InputOptions      `json:"options"`
+	Properties InputProperties   `json:"properties"`
 	Partitions []*InputPartition `json:"partitions"`
 
 	Modifications InputModifications `json:"modifications"`
 }
 
-type InputOptions struct {
+type InputProperties struct {
 	UEFI InputUEFI `json:"uefi"`
 	BIOS bool      `json:"bios"`
 	Type string    `json:"type"`
@@ -104,11 +104,11 @@ func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
 
 func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) {
 	pt := &disk.PartitionTable{
-		UUID:       input.Options.UUID,
-		Type:       input.Options.Type,
-		SectorSize: input.Options.SectorSize,
+		UUID:       input.Properties.UUID,
+		Type:       input.Properties.Type,
+		SectorSize: input.Properties.SectorSize,
 	}
-	if input.Options.BIOS {
+	if input.Properties.BIOS {
 		if len(pt.Partitions) > 0 {
 			panic("internal error: bios partition *must* go first")
 		}
@@ -119,8 +119,8 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 			UUID:     disk.BIOSBootPartitionUUID,
 		})
 	}
-	if input.Options.UEFI.Size != "" {
-		uintSize, err := common.DataSizeToUint64(input.Options.UEFI.Size)
+	if input.Properties.UEFI.Size != "" {
+		uintSize, err := common.DataSizeToUint64(input.Properties.UEFI.Size)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -23,11 +23,11 @@ type Input struct {
 }
 
 type InputProperties struct {
-	UEFI InputUEFI `json:"uefi"`
-	BIOS bool      `json:"bios"`
-	Type string    `json:"type"`
-	Size string    `json:"size"`
-	UUID string    `json:"uuid"`
+	UEFI        InputUEFI `json:"uefi"`
+	BIOS        bool      `json:"bios"`
+	Type        string    `json:"type"`
+	DefaultSize string    `json:"default_size"`
+	UUID        string    `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -23,7 +23,7 @@ var partInputsComplete = `
     },
     "bios": true,
     "type": "gpt",
-    "size": "10 GiB"
+    "default_size": "10 GiB"
   },
   "partitions": [
     {
@@ -54,9 +54,9 @@ var expectedInput = &genpart.Input{
 		UEFI: genpart.InputUEFI{
 			Size: "1 GiB",
 		},
-		BIOS: true,
-		Type: "gpt",
-		Size: "10 GiB",
+		BIOS:        true,
+		Type:        "gpt",
+		DefaultSize: "10 GiB",
 	},
 	Partitions: []*genpart.InputPartition{
 		{
@@ -170,7 +170,7 @@ var partInputsSimple = `
     },
     "bios": true,
     "type": "gpt",
-    "size": "10 GiB"
+    "default_size": "10 GiB"
   },
   "partitions": [
     {

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -42,6 +42,7 @@ var partInputsComplete = `
     }
   ],
   "modifications": {
+    "min_disk_size": "20 GiB",
     "partition_mode": "auto-lvm",
     "filesystems": [
       {"mountpoint": "/var/log", "minsize": 10241024}
@@ -74,6 +75,7 @@ var expectedInput = &genpart.Input{
 		},
 	},
 	Modifications: genpart.InputModifications{
+		MinDiskSize:   "20 GiB",
 		PartitionMode: disk.AutoLVMPartitioningMode,
 		Filesystems: []blueprint.FilesystemCustomization{
 			{
@@ -476,6 +478,103 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 								Type:         "xfs",
 								UUID:         "fb180daf-48a7-4ee0-b10d-394651850fd4",
 								FSTabOptions: "defaults",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 16106127360,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  16105078784,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			MinDiskSize: "20 GiB",
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 21474836480,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  21473787904,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
 							},
 						},
 					},

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -3,17 +3,55 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	genpart "github.com/osbuild/images/cmd/otk-gen-partition-table"
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 )
 
+// see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+var partInputsComplete = `
+{
+  "options": {
+    "uefi": {
+      "size": "1 GiB"
+    },
+    "bios": true,
+    "type": "gpt",
+    "size": "10 GiB"
+  },
+  "partitions": [
+    {
+      "name": "root",
+      "mountpoint": "/",
+      "label": "root",
+      "size": "7 GiB",
+      "type": "ext4"
+    },
+    {
+      "name": "home",
+      "mountpoint": "/home",
+      "label": "home",
+      "size": "2 GiB",
+      "type": "ext4"
+    }
+  ],
+  "modifications": {
+    "partition_mode": "auto-lvm",
+    "filesystems": [
+      {"mountpoint": "/var/log", "minsize": 10241024}
+    ]
+  }
+}`
+
 var expectedInput = &genpart.Input{
-	Options: &genpart.InputOptions{
-		UEFI: &genpart.InputUEFI{
+	Options: genpart.InputOptions{
+		UEFI: genpart.InputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
@@ -35,11 +73,20 @@ var expectedInput = &genpart.Input{
 			Type:       "ext4",
 		},
 	},
+	Modifications: genpart.InputModifications{
+		PartitionMode: disk.AutoLVMPartitioningMode,
+		Filesystems: []blueprint.FilesystemCustomization{
+			{
+				Mountpoint: "/var/log",
+				MinSize:    10241024,
+			},
+		},
+	},
 }
 
 func TestUnmarshalInput(t *testing.T) {
 	var otkInput genpart.Input
-	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
+	err := json.Unmarshal([]byte(partInputsComplete), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
@@ -115,8 +162,7 @@ func TestUnmarshalOutput(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(output))
 }
 
-// see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
-var simplePartOptions = `
+var partInputsSimple = `
 {
   "options": {
     "uefi": {
@@ -142,8 +188,7 @@ var simplePartOptions = `
       "type": "ext4"
     }
   ]
-}
-`
+}`
 
 // XXX: anything under "internal" we don't actually need to test
 // as we do not make any gurantees to the outside
@@ -227,12 +272,218 @@ var expectedSimplePartOutput = `{
 }
 `
 
-func TestIntegration(t *testing.T) {
+func TestIntegrationRealistic(t *testing.T) {
 	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")
 
-	inp := bytes.NewBufferString(simplePartOptions)
+	inp := bytes.NewBufferString(partInputsSimple)
 	outp := bytes.NewBuffer(nil)
 	err := genpart.Run(inp, outp)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSimplePartOutput, outp.String())
+}
+
+func TestGenPartitionTableMinimal(t *testing.T) {
+	// XXX: think about what the smalltest inputs can be and validate
+	// that it's complete and/or provide defaults (e.g. for "type" for
+	// partition and filesystem type)
+	inp := &genpart.Input{
+		Options: genpart.InputOptions{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10738466816,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
+	inp := &genpart.Input{
+		Options: genpart.InputOptions{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/boot",
+				Size:       "2 GiB",
+				Type:       "ext4",
+			},
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			Filesystems: []blueprint.FilesystemCustomization{
+				{
+					Mountpoint: "/var/log",
+					MinSize:    3 * common.GigaByte,
+				},
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"boot": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 15890120704,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  2147483648,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/boot",
+							},
+						},
+						{
+							Start: 2148532224,
+							Size:  13741588480,
+							Type:  "8e",
+							Payload: &disk.LVMVolumeGroup{
+								Name:        "rootvg",
+								Description: "created via lvm2 and osbuild",
+								LogicalVolumes: []disk.LVMLogicalVolume{
+									{
+										Name: "rootlv",
+										Size: 10737418240,
+										Payload: &disk.Filesystem{
+											Mountpoint: "/",
+											Type:       "ext4",
+											UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
+										},
+									}, {
+										Name: "var_loglv",
+										Size: 3003121664,
+										Payload: &disk.Filesystem{
+											Mountpoint: "/var/log",
+											// XXX: this is confusing
+											Type: "xfs",
+											UUID: "a178892e-e285-4ce1-9114-55780875d64e",
+											// XXX: is this needed?
+											FSTabOptions: "defaults",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// default partition mode is "auto-lvm" so LVM is created by default
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *testing.T) {
+	inp := &genpart.Input{
+		Options: genpart.InputOptions{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			// note that the extra partitin mode is used here
+			PartitionMode: disk.RawPartitioningMode,
+			Filesystems: []blueprint.FilesystemCustomization{
+				{
+					Mountpoint: "/var/log",
+					MinSize:    3 * common.GigaByte,
+				},
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 13739491328,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 3002073088,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Mountpoint: "/",
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							},
+						}, {
+							Start: 1048576,
+							Size:  3001024512,
+							Payload: &disk.Filesystem{
+								Mountpoint: "/var/log",
+								// XXX: this is confusing
+								Type:         "xfs",
+								UUID:         "fb180daf-48a7-4ee0-b10d-394651850fd4",
+								FSTabOptions: "defaults",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
 }

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -17,7 +17,7 @@ import (
 // see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 var partInputsComplete = `
 {
-  "options": {
+  "properties": {
     "uefi": {
       "size": "1 GiB"
     },
@@ -50,7 +50,7 @@ var partInputsComplete = `
 }`
 
 var expectedInput = &genpart.Input{
-	Options: genpart.InputOptions{
+	Properties: genpart.InputProperties{
 		UEFI: genpart.InputUEFI{
 			Size: "1 GiB",
 		},
@@ -164,7 +164,7 @@ func TestUnmarshalOutput(t *testing.T) {
 
 var partInputsSimple = `
 {
-  "options": {
+  "properties": {
     "uefi": {
       "size": "1 GiB"
     },
@@ -287,7 +287,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 	// that it's complete and/or provide defaults (e.g. for "type" for
 	// partition and filesystem type)
 	inp := &genpart.Input{
-		Options: genpart.InputOptions{
+		Properties: genpart.InputProperties{
 			Type: "dos",
 		},
 		Partitions: []*genpart.InputPartition{
@@ -333,7 +333,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 
 func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 	inp := &genpart.Input{
-		Options: genpart.InputOptions{
+		Properties: genpart.InputProperties{
 			Type: "dos",
 		},
 		Partitions: []*genpart.InputPartition{
@@ -424,7 +424,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 
 func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *testing.T) {
 	inp := &genpart.Input{
-		Options: genpart.InputOptions{
+		Properties: genpart.InputProperties{
 			Type: "dos",
 		},
 		Partitions: []*genpart.InputPartition{


### PR DESCRIPTION
This commit adds a new `modifications` field to the input of the
`otk-gen-partition-table` that can be used to tweak the output
of the partition generator.

The inputs follow the inputs from the existing customizations, so
the json input looks like this:
```json
{
  ...
  "modifications": {
    "partition_mode": "raw",
    "filesystems": [
      {"mountpoint": "/var/log", "minsize": 10241024}
    ],
   "min_disk_size": "12 GiB",
  }
}
```

and the otk snippet would look something like:
```yaml
filesystem:
  otk.external.gen_partition_table:
    options: ...
    partitions: ...
    modifications:
      partition_mode: ${modifications.partition_mode}
      filesystems: ${modfications.filesystems}
```
and the user would override them via:
```sh
cat > mymod.json <<'EOF'
{
  "modifications": {
    "partition_mode": "raw",
    "filesystems: [ {"mountpoint": "/var/log", "minsize": 10241024 } ]
}
EOF
$ otk compile --modifications=mymod.json centos-9-x86_64-ami.otk
```

One open question is if we should have "minsize" as a string instead of as an integer - my gut feeling is yes this is why it's draft right now.


build on top of https://github.com/achilleas-k/images/pull/4 