### PR TITLE
otk-make-partition-stages: add new `otk-make-partition-stages` external

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/otk"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -75,9 +76,7 @@ type OutputPartition struct {
 	UUID string `json:"uuid"`
 }
 
-type OutputInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
-}
+type OutputInternal = otk.PartitionInternal
 
 func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
 	pm := make(map[string]OutputPartition, len(pt.Partitions))

--- a/cmd/otk-make-partition-stages/export_test.go
+++ b/cmd/otk-make-partition-stages/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var Run = run

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+// keep in sync with "otk-gen-partition-table"
+type Input struct {
+	Internal InputInternal `json:"internal"`
+}
+
+type InputInternal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}
+
+func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cannot generate image prepare stages: %v", r)
+		}
+	}()
+
+	// XXX: would we ever want to change that?
+	partTool := osbuild.PTSfdisk
+	stages = osbuild.GenImagePrepareStages(inp.Internal.PartitionTable, filename, partTool)
+	return stages, nil
+}
+
+func run(r io.Reader, w io.Writer) error {
+	var inp Input
+	if err := json.NewDecoder(r).Decode(&inp); err != nil {
+		return err
+	}
+
+	// XXX: make configurable via "modification"
+	fname := "disk.img"
+	stages, err := makeImagePrepareStages(inp, fname)
+	if err != nil {
+		return fmt.Errorf("cannot make partition stages: %w", err)
+	}
+
+	outputJson, err := json.MarshalIndent(stages, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal response: %w", err)
+	}
+	fmt.Fprintf(w, "%s\n", outputJson)
+	return nil
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -12,11 +12,17 @@ import (
 
 // keep in sync with "otk-gen-partition-table"
 type Input struct {
-	Internal InputInternal `json:"internal"`
+	Internal      InputInternal      `json:"internal"`
+	Modifications InputModifications `json:"modifications"`
 }
 
 type InputInternal struct {
 	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}
+
+type InputModifications struct {
+	// XXX: or "basename"?
+	Filename string `json:"filename"`
 }
 
 func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage, err error) {
@@ -38,8 +44,10 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	// XXX: make configurable via "modification"
 	fname := "disk.img"
+	if inp.Modifications.Filename != "" {
+		fname = inp.Modifications.Filename
+	}
 	stages, err := makeImagePrepareStages(inp, fname)
 	if err != nil {
 		return fmt.Errorf("cannot make partition stages: %w", err)

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -6,19 +6,17 @@ import (
 	"io"
 	"os"
 
-	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
+
+	"github.com/osbuild/images/internal/otk"
 )
 
-// keep in sync with "otk-gen-partition-table"
 type Input struct {
 	Internal      InputInternal      `json:"internal"`
 	Modifications InputModifications `json:"modifications"`
 }
 
-type InputInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
-}
+type InputInternal = otk.PartitionInternal
 
 type InputModifications struct {
 	// XXX: or "basename"?

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -19,7 +19,6 @@ type Input struct {
 type InputInternal = otk.PartitionInternal
 
 type InputModifications struct {
-	// XXX: or "basename"?
 	Filename string `json:"filename"`
 }
 
@@ -30,7 +29,8 @@ func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage
 		}
 	}()
 
-	// XXX: would we ever want to change that?
+	// rhel7 uses PTSgdisk, if we ever need to support this, make this
+	// configurable
 	partTool := osbuild.PTSfdisk
 	stages = osbuild.GenImagePrepareStages(inp.Internal.PartitionTable, filename, partTool)
 	return stages, nil

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,32 +12,32 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-func TestIntegration(t *testing.T) {
-	// this is not symetrical to the output, this is sad but also
-	// okay because the input is really just a dump of the internal
-	// disk.PartitionTable so encoding it in json here will not add
-	// a benefit for the test
-	minimalInput := makestages.Input{
-		Internal: makestages.InputInternal{
-			PartitionTable: &disk.PartitionTable{
-				Size: 10738466816,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Type: "dos",
-				Partitions: []disk.Partition{
-					{
-						Start: 1048576,
-						Size:  10737418240,
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-							Mountpoint: "/",
-						},
+// this is not symetrical to the output, this is sad but also
+// okay because the input is really just a dump of the internal
+// disk.PartitionTable so encoding it in json here will not add
+// a benefit for the test
+var minimalInputBase = makestages.Input{
+	Internal: makestages.InputInternal{
+		PartitionTable: &disk.PartitionTable{
+			Size: 10738466816,
+			UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+			Type: "dos",
+			Partitions: []disk.Partition{
+				{
+					Start: 1048576,
+					Size:  10737418240,
+					Payload: &disk.Filesystem{
+						Type:       "ext4",
+						UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+						Mountpoint: "/",
 					},
 				},
 			},
 		},
-	}
-	expectedStages := `[
+	},
+}
+
+var minimalExpectedStages = `[
   {
     "type": "org.osbuild.truncate",
     "options": {
@@ -85,7 +86,28 @@ func TestIntegration(t *testing.T) {
   }
 ]
 `
+
+func TestIntegration(t *testing.T) {
+	minimalInput := minimalInputBase
+	expectedStages := minimalExpectedStages
+
 	inpJSON, err := json.Marshal(&minimalInput)
+	assert.NoError(t, err)
+	fakeStdin := bytes.NewBuffer(inpJSON)
+	fakeStdout := bytes.NewBuffer(nil)
+
+	err = makestages.Run(fakeStdin, fakeStdout)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedStages, fakeStdout.String())
+}
+
+func TestModificationFname(t *testing.T) {
+	input := minimalInputBase
+	input.Modifications.Filename = "mydisk.img2"
+	expectedStages := strings.Replace(minimalExpectedStages, `"disk.img"`, `"mydisk.img2"`, -1)
+
+	inpJSON, err := json.Marshal(&input)
 	assert.NoError(t, err)
 	fakeStdin := bytes.NewBuffer(inpJSON)
 	fakeStdout := bytes.NewBuffer(nil)

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -1,0 +1,97 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	makestages "github.com/osbuild/images/cmd/otk-make-partition-stages"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+func TestIntegration(t *testing.T) {
+	// this is not symetrical to the output, this is sad but also
+	// okay because the input is really just a dump of the internal
+	// disk.PartitionTable so encoding it in json here will not add
+	// a benefit for the test
+	minimalInput := makestages.Input{
+		Internal: makestages.InputInternal{
+			PartitionTable: &disk.PartitionTable{
+				Size: 10738466816,
+				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Start: 1048576,
+						Size:  10737418240,
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							Mountpoint: "/",
+						},
+					},
+				},
+			},
+		},
+	}
+	expectedStages := `[
+  {
+    "type": "org.osbuild.truncate",
+    "options": {
+      "filename": "disk.img",
+      "size": "10738466816"
+    }
+  },
+  {
+    "type": "org.osbuild.sfdisk",
+    "options": {
+      "label": "dos",
+      "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+      "partitions": [
+        {
+          "size": 20971520,
+          "start": 2048
+        }
+      ]
+    },
+    "devices": {
+      "device": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "disk.img",
+          "lock": true
+        }
+      }
+    }
+  },
+  {
+    "type": "org.osbuild.mkfs.ext4",
+    "options": {
+      "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+    },
+    "devices": {
+      "device": {
+        "type": "org.osbuild.loopback",
+        "options": {
+          "filename": "disk.img",
+          "start": 2048,
+          "size": 20971520,
+          "lock": true
+        }
+      }
+    }
+  }
+]
+`
+	inpJSON, err := json.Marshal(&minimalInput)
+	assert.NoError(t, err)
+	fakeStdin := bytes.NewBuffer(inpJSON)
+	fakeStdout := bytes.NewBuffer(nil)
+
+	err = makestages.Run(fakeStdin, fakeStdout)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedStages, fakeStdout.String())
+}

--- a/internal/otk/partition.go
+++ b/internal/otk/partition.go
@@ -1,0 +1,9 @@
+package otk
+
+import (
+	"github.com/osbuild/images/pkg/disk"
+)
+
+type PartitionInternal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}


### PR DESCRIPTION
This external will consume the data from `otk-gen-partition-table` and generate `osbuild` stages from it.

The expected usage is something like:
```yaml
otk.define.modifciations.defauls:
 modifications:
  filesystem:
    min_disk_size: 20 GiB
    image_filename: disk.img

otk.define.defaults:
 filesystem:
   otk.external.gen_partition_table:
     modifications: ${modifications.filesystem}
     properties: ...
     partitions: ...

stages:
 ...
 otk.external.make_partition_stages:
   internal: ${filesystem.internal}
   filename: ${modifications.filesystem.image_filename}
```