### PR TITLE
Cmd/partition table

### DIFF
--- a/cmd/otk-gen-partition-table/export_test.go
+++ b/cmd/otk-gen-partition-table/export_test.go
@@ -1,3 +1,6 @@
 package main
 
-var Run = run
+var (
+	Run               = run
+	GenPartitionTable = genPartitionTable
+)

--- a/cmd/otk-gen-partition-table/export_test.go
+++ b/cmd/otk-gen-partition-table/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var Run = run

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -71,8 +71,24 @@ type OtkGenPartConstOutput struct {
 }
 
 func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
-	// XXX: implement me
-	return nil
+	pm := make(map[string]OtkPublicPartition, len(pt.Partitions))
+	for _, part := range pt.Partitions {
+		switch pl := part.Payload.(type) {
+		case *disk.Filesystem:
+			switch pl.Mountpoint {
+			case "/":
+				pm["root"] = OtkPublicPartition{
+					UUID: pl.UUID,
+				}
+			case "/boot":
+				pm["boot"] = OtkPublicPartition{
+					UUID: pl.UUID,
+				}
+			}
+		}
+	}
+
+	return pm
 }
 
 func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.PartitionTable, error) {

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -72,6 +72,9 @@ type OtkGenPartConstOutput struct {
 
 func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
 	pm := make(map[string]OtkPublicPartition, len(pt.Partitions))
+	// TODO: think about exposing more partitions, if we do, what labels
+	// would we use? OtkPartition.Name? what about clashes with
+	// "{r,b}oot" then?
 	for _, part := range pt.Partitions {
 		switch pl := part.Payload.(type) {
 		case *disk.Filesystem:
@@ -150,6 +153,9 @@ func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.Partitio
 	return pt, nil
 }
 
+// Missing:
+// 1. customizations^Wmodifications, e.g. extra partiton tables
+// 2. refactor, make this nicer, it sucks a bit right now
 func run(r io.Reader, rng *rand.Rand) (*OtkGenPartitionsOutput, error) {
 	var genPartInput OtkGenPartitionInput
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/osbuild"
 )
 
 // TODO: read  this from the input - the tool itself should not have a base PT
@@ -66,24 +67,9 @@ var basePt = disk.PartitionTable{
 	},
 }
 
-// Serializable version of the partition table that is used for formatting the
-// output of this command.
-type partitionTable struct {
-	Size       uint64 `json:"size"`
-	UUID       string `json:"uuid"`
-	Type       string `json:"type"`
-	SectorSize uint64 `json:"sector_size"`
-
-	Partitions []partition
-}
-
-type partition struct {
-	Start    uint64 `json:"start"`
-	Size     uint64 `json:"size"`
-	Type     string `json:"type"`
-	Bootable bool   `json:"bootable"`
-
-	UUID string `json:"uuid"`
+type otkGenPartitionsJSON struct {
+	PartitionTable *disk.PartitionTable `json:"internal-partition-table"`
+	KernelOptsList []string             `json:"kernel_opts_list"`
 }
 
 func main() {
@@ -103,9 +89,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	ptJson, err := json.Marshal(pt)
+	kernelOptions := osbuild.GenImageKernelOptions(pt)
+	otkPart := otkGenPartitionsJSON{
+		PartitionTable: pt,
+		KernelOptsList: kernelOptions,
+	}
+	ptJson, err := json.Marshal(otkPart)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to martial partition table: %s\n", err.Error())
 	}
-	fmt.Println(string(ptJson))
+
+	fmt.Printf("%s\n", ptJson)
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -14,60 +14,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-// TODO: read  this from the input - the tool itself should not have a base PT
-var basePt = disk.PartitionTable{
-	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-	Type: "gpt",
-	Partitions: []disk.Partition{
-		{
-			Size:     1 * common.MebiByte,
-			Bootable: true,
-			Type:     disk.BIOSBootPartitionGUID,
-			UUID:     disk.BIOSBootPartitionUUID,
-		},
-		{
-			Size: 200 * common.MebiByte,
-			Type: disk.EFISystemPartitionGUID,
-			UUID: disk.EFISystemPartitionUUID,
-			Payload: &disk.Filesystem{
-				Type:         "vfat",
-				UUID:         disk.EFIFilesystemUUID,
-				Mountpoint:   "/boot/efi",
-				Label:        "EFI-SYSTEM",
-				FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-				FSTabFreq:    0,
-				FSTabPassNo:  2,
-			},
-		},
-		{
-			Size: 500 * common.MebiByte,
-			Type: disk.FilesystemDataGUID,
-			UUID: disk.FilesystemDataUUID,
-			Payload: &disk.Filesystem{
-				Type:         "ext4",
-				Mountpoint:   "/boot",
-				Label:        "boot",
-				FSTabOptions: "defaults",
-				FSTabFreq:    0,
-				FSTabPassNo:  0,
-			},
-		},
-		{
-			Size: 2 * common.GibiByte,
-			Type: disk.FilesystemDataGUID,
-			UUID: disk.RootPartitionUUID,
-			Payload: &disk.Filesystem{
-				Type:         "ext4",
-				Label:        "root",
-				Mountpoint:   "/",
-				FSTabOptions: "defaults",
-				FSTabFreq:    0,
-				FSTabPassNo:  0,
-			},
-		},
-	},
-}
-
 type OtkGenPartitionInput struct {
 	Options    *OtkPartOptions `json:"options"`
 	Partitions []*OtkPartition `json:"partitions"`

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -14,26 +14,26 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type OtkGenPartitionInput struct {
-	Options    *OtkPartOptions `json:"options"`
-	Partitions []*OtkPartition `json:"partitions"`
+type OtkPartInput struct {
+	Options    *OtkPartInputOptions     `json:"options"`
+	Partitions []*OtkPartInputPartition `json:"partitions"`
 }
 
-type OtkPartOptions struct {
-	UEFI *OtkPartUEFI `json:"uefi"`
-	BIOS bool         `json:"bios"`
-	Type string       `json:"type"`
-	Size string       `json:"size"`
-	UUID string       `json:"uuid"`
+type OtkPartInputOptions struct {
+	UEFI *OtkPartInputUEFI `json:"uefi"`
+	BIOS bool              `json:"bios"`
+	Type string            `json:"type"`
+	Size string            `json:"size"`
+	UUID string            `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
 
-type OtkPartUEFI struct {
+type OtkPartInputUEFI struct {
 	Size string `json:"size"`
 }
 
-type OtkPartition struct {
+type OtkPartInputPartition struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
 	Label      string `json:"label"`
@@ -47,32 +47,31 @@ type OtkPartition struct {
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 }
 
-// XXX: review all struct names and make them consistent (OtkOutput*?)
-type OtkGenPartitionsOutput struct {
-	Const OtkGenPartConstOutput `json:"const"`
+type OtkPartOutput struct {
+	Const OtkPartOutputConst `json:"const"`
 }
 
-type OtkGenPartitionsInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
+type OtkPartOutputConst struct {
+	KernelOptsList []string `json:"kernel_opts_list"`
+	// we generate this for convenience for otk users, so that they
+	// can write, e.g. "filesystem.partition_map.boot.uuid"
+	PartitionMap map[string]OtkPartOutputPartition `json:"partition_map"`
+	Internal     OtkPartOutputInternal             `json:"internal"`
 }
 
 // "exported" view of partitions, this is an API so only add things here
 // that are really needed and unlikely to change
-type OtkPublicPartition struct {
+type OtkPartOutputPartition struct {
 	// not a UUID type because fat UUIDs are not compliant
 	UUID string `json:"uuid"`
 }
 
-type OtkGenPartConstOutput struct {
-	KernelOptsList []string `json:"kernel_opts_list"`
-	// we generate this for convenience for otk users, so that they
-	// can write, e.g. "filesystem.partition_map.boot.uuid"
-	PartitionMap map[string]OtkPublicPartition `json:"partition_map"`
-	Internal     OtkGenPartitionsInternal      `json:"internal"`
+type OtkPartOutputInternal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
 }
 
-func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
-	pm := make(map[string]OtkPublicPartition, len(pt.Partitions))
+func makePartMap(pt *disk.PartitionTable) map[string]OtkPartOutputPartition {
+	pm := make(map[string]OtkPartOutputPartition, len(pt.Partitions))
 	// TODO: think about exposing more partitions, if we do, what labels
 	// would we use? OtkPartition.Name? what about clashes with
 	// "{r,b}oot" then?
@@ -81,11 +80,11 @@ func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
 		case *disk.Filesystem:
 			switch pl.Mountpoint {
 			case "/":
-				pm["root"] = OtkPublicPartition{
+				pm["root"] = OtkPartOutputPartition{
 					UUID: pl.UUID,
 				}
 			case "/boot":
-				pm["boot"] = OtkPublicPartition{
+				pm["boot"] = OtkPartOutputPartition{
 					UUID: pl.UUID,
 				}
 			}
@@ -95,7 +94,7 @@ func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
 	return pm
 }
 
-func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.PartitionTable, error) {
+func makePartitionTableFromOtkInput(input *OtkPartInput) (*disk.PartitionTable, error) {
 	pt := &disk.PartitionTable{
 		UUID:       input.Options.UUID,
 		Type:       input.Options.Type,
@@ -161,7 +160,7 @@ func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.Partitio
 // Missing:
 // 1. customizations^Wmodifications, e.g. extra partiton tables
 // 2. refactor, make this nicer, it sucks a bit right now
-func genPartitionTable(genPartInput *OtkGenPartitionInput, rng *rand.Rand) (*OtkGenPartitionsOutput, error) {
+func genPartitionTable(genPartInput *OtkPartInput, rng *rand.Rand) (*OtkPartOutput, error) {
 	basePt, err := makePartitionTableFromOtkInput(genPartInput)
 	if err != nil {
 		return nil, err
@@ -173,9 +172,9 @@ func genPartitionTable(genPartInput *OtkGenPartitionInput, rng *rand.Rand) (*Otk
 	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
-	otkPart := &OtkGenPartitionsOutput{
-		Const: OtkGenPartConstOutput{
-			Internal: OtkGenPartitionsInternal{
+	otkPart := &OtkPartOutput{
+		Const: OtkPartOutputConst{
+			Internal: OtkPartOutputInternal{
 				PartitionTable: pt,
 			},
 			KernelOptsList: kernelOptions,
@@ -195,7 +194,7 @@ func run(r io.Reader, w io.Writer) error {
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(rngSeed))
 
-	var genPartInput OtkGenPartitionInput
+	var genPartInput OtkPartInput
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return err
 	}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -67,37 +67,52 @@ var basePt = disk.PartitionTable{
 	},
 }
 
-type otkGenPartitionsJSON struct {
+type otkGenPartitionInput struct {
+	TotalSize uint64 `json:"total_size"`
+}
+
+type otkGenPartitionsOutput struct {
 	PartitionTable *disk.PartitionTable `json:"internal-partition-table"`
 	KernelOptsList []string             `json:"kernel_opts_list"`
 }
 
-func main() {
+func run() error {
+	var genPartInput otkGenPartitionInput
+	if err := json.NewDecoder(os.Stdin).Decode(&genPartInput); err != nil {
+		return err
+	}
+
 	rngSeed, err := cmdutil.SeedArgFor(&buildconfig.BuildConfig{}, "", "", "")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
-		os.Exit(1)
+		return err
 	}
 	source := rand.NewSource(rngSeed)
 	// math/rand is good enough in this case
 	/* #nosec G404 */
 	rng := rand.New(source)
 
-	pt, err := disk.NewPartitionTable(&basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(&basePt, nil, genPartInput.TotalSize, disk.DefaultPartitioningMode, nil, rng)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
-	otkPart := otkGenPartitionsJSON{
+	otkPart := otkGenPartitionsOutput{
 		PartitionTable: pt,
 		KernelOptsList: kernelOptions,
 	}
 	ptJson, err := json.Marshal(otkPart)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to martial partition table: %s\n", err.Error())
+		return fmt.Errorf("failed to martial partition table: %w\n", err)
 	}
 
 	fmt.Printf("%s\n", ptJson)
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -10,21 +10,24 @@ import (
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
 type Input struct {
-	Options    *InputOptions     `json:"options"`
+	Options    InputOptions      `json:"options"`
 	Partitions []*InputPartition `json:"partitions"`
+
+	Modifications InputModifications `json:"modifications"`
 }
 
 type InputOptions struct {
-	UEFI *InputUEFI `json:"uefi"`
-	BIOS bool       `json:"bios"`
-	Type string     `json:"type"`
-	Size string     `json:"size"`
-	UUID string     `json:"uuid"`
+	UEFI InputUEFI `json:"uefi"`
+	BIOS bool      `json:"bios"`
+	Type string    `json:"type"`
+	Size string    `json:"size"`
+	UUID string    `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
@@ -45,6 +48,11 @@ type InputPartition struct {
 	FSPassNo   uint64 `json:"fs_passno"`
 
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+}
+
+type InputModifications struct {
+	PartitionMode disk.PartitioningMode               `json:"partition_mode"`
+	Filesystems   []blueprint.FilesystemCustomization `json:"filesystems"`
 }
 
 type Output struct {
@@ -157,16 +165,12 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 	return pt, nil
 }
 
-// Missing:
-// 1. customizations^Wmodifications, e.g. extra partiton tables
-// 2. refactor, make this nicer, it sucks a bit right now
 func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	basePt, err := makePartitionTableFromOtkInput(genPartInput)
 	if err != nil {
 		return nil, err
 	}
-
-	pt, err := disk.NewPartitionTable(basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(basePt, genPartInput.Modifications.Filesystems, 0, genPartInput.Modifications.PartitionMode, nil, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -198,6 +202,9 @@ func run(r io.Reader, w io.Writer) error {
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return err
 	}
+	// XXX: validate inputs, right now an empty "type" is not an error
+	// but it should either be an error or we should set a default
+
 	output, err := genPartitionTable(&genPartInput, rng)
 	if err != nil {
 		return fmt.Errorf("cannot generate partition table: %w", err)

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -16,13 +16,13 @@ import (
 )
 
 type Input struct {
-	Options    InputOptions      `json:"options"`
+	Properties InputProperties   `json:"properties"`
 	Partitions []*InputPartition `json:"partitions"`
 
 	Modifications InputModifications `json:"modifications"`
 }
 
-type InputOptions struct {
+type InputProperties struct {
 	UEFI InputUEFI `json:"uefi"`
 	BIOS bool      `json:"bios"`
 	Type string    `json:"type"`
@@ -104,11 +104,11 @@ func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
 
 func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) {
 	pt := &disk.PartitionTable{
-		UUID:       input.Options.UUID,
-		Type:       input.Options.Type,
-		SectorSize: input.Options.SectorSize,
+		UUID:       input.Properties.UUID,
+		Type:       input.Properties.Type,
+		SectorSize: input.Properties.SectorSize,
 	}
-	if input.Options.BIOS {
+	if input.Properties.BIOS {
 		if len(pt.Partitions) > 0 {
 			panic("internal error: bios partition *must* go first")
 		}
@@ -119,8 +119,8 @@ func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) 
 			UUID:     disk.BIOSBootPartitionUUID,
 		})
 	}
-	if input.Options.UEFI.Size != "" {
-		uintSize, err := common.DataSizeToUint64(input.Options.UEFI.Size)
+	if input.Properties.UEFI.Size != "" {
+		uintSize, err := common.DataSizeToUint64(input.Properties.UEFI.Size)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -23,11 +23,11 @@ type Input struct {
 }
 
 type InputProperties struct {
-	UEFI InputUEFI `json:"uefi"`
-	BIOS bool      `json:"bios"`
-	Type string    `json:"type"`
-	Size string    `json:"size"`
-	UUID string    `json:"uuid"`
+	UEFI        InputUEFI `json:"uefi"`
+	BIOS        bool      `json:"bios"`
+	Type        string    `json:"type"`
+	DefaultSize string    `json:"default_size"`
+	UUID        string    `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -52,7 +52,7 @@ type OtkGenPartitionsOutput struct {
 }
 
 type OtkGenPartitionsInternal struct {
-	PartitionTable *disk.PartitionTable `json:"internal-partition-table"`
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
 }
 
 // "exported" view of partitions, this is an API so only add things here

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -202,5 +202,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
 		os.Exit(1)
 	}
-	fmt.Println(output)
+
+	outputJson, err := json.Marshal(output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		os.Exit(1)
+	}
+	fmt.Print(string(outputJson))
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -14,26 +14,26 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type OtkPartInput struct {
-	Options    *OtkPartInputOptions     `json:"options"`
-	Partitions []*OtkPartInputPartition `json:"partitions"`
+type Input struct {
+	Options    *InputOptions     `json:"options"`
+	Partitions []*InputPartition `json:"partitions"`
 }
 
-type OtkPartInputOptions struct {
-	UEFI *OtkPartInputUEFI `json:"uefi"`
-	BIOS bool              `json:"bios"`
-	Type string            `json:"type"`
-	Size string            `json:"size"`
-	UUID string            `json:"uuid"`
+type InputOptions struct {
+	UEFI *InputUEFI `json:"uefi"`
+	BIOS bool       `json:"bios"`
+	Type string     `json:"type"`
+	Size string     `json:"size"`
+	UUID string     `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
 
-type OtkPartInputUEFI struct {
+type InputUEFI struct {
 	Size string `json:"size"`
 }
 
-type OtkPartInputPartition struct {
+type InputPartition struct {
 	Name       string `json:"name"`
 	Mountpoint string `json:"mountpoint"`
 	Label      string `json:"label"`
@@ -47,44 +47,44 @@ type OtkPartInputPartition struct {
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 }
 
-type OtkPartOutput struct {
-	Const OtkPartOutputConst `json:"const"`
+type Output struct {
+	Const OutputConst `json:"const"`
 }
 
-type OtkPartOutputConst struct {
+type OutputConst struct {
 	KernelOptsList []string `json:"kernel_opts_list"`
 	// we generate this for convenience for otk users, so that they
 	// can write, e.g. "filesystem.partition_map.boot.uuid"
-	PartitionMap map[string]OtkPartOutputPartition `json:"partition_map"`
-	Internal     OtkPartOutputInternal             `json:"internal"`
+	PartitionMap map[string]OutputPartition `json:"partition_map"`
+	Internal     OutputInternal             `json:"internal"`
 }
 
 // "exported" view of partitions, this is an API so only add things here
 // that are really needed and unlikely to change
-type OtkPartOutputPartition struct {
+type OutputPartition struct {
 	// not a UUID type because fat UUIDs are not compliant
 	UUID string `json:"uuid"`
 }
 
-type OtkPartOutputInternal struct {
+type OutputInternal struct {
 	PartitionTable *disk.PartitionTable `json:"partition-table"`
 }
 
-func makePartMap(pt *disk.PartitionTable) map[string]OtkPartOutputPartition {
-	pm := make(map[string]OtkPartOutputPartition, len(pt.Partitions))
+func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
+	pm := make(map[string]OutputPartition, len(pt.Partitions))
 	// TODO: think about exposing more partitions, if we do, what labels
-	// would we use? OtkPartition.Name? what about clashes with
+	// would we use? ition.Name? what about clashes with
 	// "{r,b}oot" then?
 	for _, part := range pt.Partitions {
 		switch pl := part.Payload.(type) {
 		case *disk.Filesystem:
 			switch pl.Mountpoint {
 			case "/":
-				pm["root"] = OtkPartOutputPartition{
+				pm["root"] = OutputPartition{
 					UUID: pl.UUID,
 				}
 			case "/boot":
-				pm["boot"] = OtkPartOutputPartition{
+				pm["boot"] = OutputPartition{
 					UUID: pl.UUID,
 				}
 			}
@@ -94,7 +94,7 @@ func makePartMap(pt *disk.PartitionTable) map[string]OtkPartOutputPartition {
 	return pm
 }
 
-func makePartitionTableFromOtkInput(input *OtkPartInput) (*disk.PartitionTable, error) {
+func makePartitionTableFromOtkInput(input *Input) (*disk.PartitionTable, error) {
 	pt := &disk.PartitionTable{
 		UUID:       input.Options.UUID,
 		Type:       input.Options.Type,
@@ -160,7 +160,7 @@ func makePartitionTableFromOtkInput(input *OtkPartInput) (*disk.PartitionTable, 
 // Missing:
 // 1. customizations^Wmodifications, e.g. extra partiton tables
 // 2. refactor, make this nicer, it sucks a bit right now
-func genPartitionTable(genPartInput *OtkPartInput, rng *rand.Rand) (*OtkPartOutput, error) {
+func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	basePt, err := makePartitionTableFromOtkInput(genPartInput)
 	if err != nil {
 		return nil, err
@@ -172,9 +172,9 @@ func genPartitionTable(genPartInput *OtkPartInput, rng *rand.Rand) (*OtkPartOutp
 	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
-	otkPart := &OtkPartOutput{
-		Const: OtkPartOutputConst{
-			Internal: OtkPartOutputInternal{
+	otkPart := &Output{
+		Const: OutputConst{
+			Internal: OutputInternal{
 				PartitionTable: pt,
 			},
 			KernelOptsList: kernelOptions,
@@ -194,7 +194,7 @@ func run(r io.Reader, w io.Writer) error {
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(rngSeed))
 
-	var genPartInput OtkPartInput
+	var genPartInput Input
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return err
 	}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -22,10 +22,9 @@ type OtkGenPartitionInput struct {
 type OtkPartOptions struct {
 	UEFI *OtkPartUEFI `json:"uefi"`
 	BIOS bool         `json:"bios"`
-	// XXX: enum?
-	Type string `json:"type"`
-	Size string `json:"size"`
-	UUID string `json:"uuid"`
+	Type string       `json:"type"`
+	Size string       `json:"size"`
+	UUID string       `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -1,5 +1,111 @@
 package main
 
-func main() {
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
 
+	"github.com/osbuild/images/internal/buildconfig"
+	"github.com/osbuild/images/internal/cmdutil"
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+// TODO: read  this from the input - the tool itself should not have a base PT
+var basePt = disk.PartitionTable{
+	UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+	Type: "gpt",
+	Partitions: []disk.Partition{
+		{
+			Size:     1 * common.MebiByte,
+			Bootable: true,
+			Type:     disk.BIOSBootPartitionGUID,
+			UUID:     disk.BIOSBootPartitionUUID,
+		},
+		{
+			Size: 200 * common.MebiByte,
+			Type: disk.EFISystemPartitionGUID,
+			UUID: disk.EFISystemPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:         "vfat",
+				UUID:         disk.EFIFilesystemUUID,
+				Mountpoint:   "/boot/efi",
+				Label:        "EFI-SYSTEM",
+				FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+				FSTabFreq:    0,
+				FSTabPassNo:  2,
+			},
+		},
+		{
+			Size: 500 * common.MebiByte,
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.FilesystemDataUUID,
+			Payload: &disk.Filesystem{
+				Type:         "ext4",
+				Mountpoint:   "/boot",
+				Label:        "boot",
+				FSTabOptions: "defaults",
+				FSTabFreq:    0,
+				FSTabPassNo:  0,
+			},
+		},
+		{
+			Size: 2 * common.GibiByte,
+			Type: disk.FilesystemDataGUID,
+			UUID: disk.RootPartitionUUID,
+			Payload: &disk.Filesystem{
+				Type:         "ext4",
+				Label:        "root",
+				Mountpoint:   "/",
+				FSTabOptions: "defaults",
+				FSTabFreq:    0,
+				FSTabPassNo:  0,
+			},
+		},
+	},
+}
+
+// Serializable version of the partition table that is used for formatting the
+// output of this command.
+type partitionTable struct {
+	Size       uint64 `json:"size"`
+	UUID       string `json:"uuid"`
+	Type       string `json:"type"`
+	SectorSize uint64 `json:"sector_size"`
+
+	Partitions []partition
+}
+
+type partition struct {
+	Start    uint64 `json:"start"`
+	Size     uint64 `json:"size"`
+	Type     string `json:"type"`
+	Bootable bool   `json:"bootable"`
+
+	UUID string `json:"uuid"`
+}
+
+func main() {
+	rngSeed, err := cmdutil.SeedArgFor(&buildconfig.BuildConfig{}, "", "", "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	source := rand.NewSource(rngSeed)
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rng := rand.New(source)
+
+	pt, err := disk.NewPartitionTable(&basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	ptJson, err := json.Marshal(pt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to martial partition table: %s\n", err.Error())
+	}
+	fmt.Println(string(ptJson))
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 
@@ -67,8 +68,35 @@ var basePt = disk.PartitionTable{
 	},
 }
 
-type otkGenPartitionInput struct {
-	TotalSize uint64 `json:"total_size"`
+type OtkGenPartitionInput struct {
+	Options    *OtkPartOptions `json:"options"`
+	Partitions []*OtkPartition `json:"partitions"`
+}
+
+type OtkPartOptions struct {
+	Uefi *OtkPartUEFI `json:"uefi"`
+	Bios bool         `json:"bios"`
+	// XXX: enum?
+	Type string `json:"type"`
+	Size string `json:"size"`
+
+	SectorSize uint64 `json:"sector_size"`
+}
+
+type OtkPartUEFI struct {
+	Size string `json:"size"`
+}
+
+type OtkPartition struct {
+	Name       string `json:"name"`
+	Mountpoint string `json:"mountpoint"`
+	Label      string `json:"label"`
+	Size       string `json:"size"`
+	Type       string `json:"type"`
+
+	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+	// also add "uuid", "freq", more(?) so that users can override calculcated
+	// values in a controlled way
 }
 
 type otkGenPartitionsOutput struct {
@@ -76,43 +104,40 @@ type otkGenPartitionsOutput struct {
 	KernelOptsList []string             `json:"kernel_opts_list"`
 }
 
-func run() error {
-	var genPartInput otkGenPartitionInput
-	if err := json.NewDecoder(os.Stdin).Decode(&genPartInput); err != nil {
-		return err
+func run(r io.Reader) (*otkGenPartitionsOutput, error) {
+	var genPartInput OtkGenPartitionInput
+	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
+		return nil, err
 	}
 
 	rngSeed, err := cmdutil.SeedArgFor(&buildconfig.BuildConfig{}, "", "", "")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	source := rand.NewSource(rngSeed)
 	// math/rand is good enough in this case
 	/* #nosec G404 */
 	rng := rand.New(source)
 
-	pt, err := disk.NewPartitionTable(&basePt, nil, genPartInput.TotalSize, disk.DefaultPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(&basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
-	otkPart := otkGenPartitionsOutput{
+	otkPart := &otkGenPartitionsOutput{
 		PartitionTable: pt,
 		KernelOptsList: kernelOptions,
 	}
-	ptJson, err := json.Marshal(otkPart)
-	if err != nil {
-		return fmt.Errorf("failed to martial partition table: %w\n", err)
-	}
 
-	fmt.Printf("%s\n", ptJson)
-	return nil
+	return otkPart, nil
 }
 
 func main() {
-	if err := run(); err != nil {
+	output, err := run(os.Stdin)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
 		os.Exit(1)
 	}
+	fmt.Println(output)
 }

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -39,10 +39,12 @@ type OtkPartition struct {
 	Label      string `json:"label"`
 	Size       string `json:"size"`
 	Type       string `json:"type"`
+	UUID       string `json:"uuid"`
+	FSMntOps   string `json:"fs_mntops"`
+	FSFreq     uint64 `json:"fs_freq"`
+	FSPassNo   uint64 `json:"fs_passno"`
 
 	// TODO: add sectorlvm,luks, see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
-	// also add "uuid", "freq", more(?) so that users can override calculcated
-	// values in a controlled way
 }
 
 // XXX: review all struct names and make them consistent (OtkOutput*?)
@@ -142,9 +144,13 @@ func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.Partitio
 			Size: uintSize,
 			// XXX: support lvm,luks here
 			Payload: &disk.Filesystem{
-				Label:      part.Label,
-				Type:       part.Type,
-				Mountpoint: part.Mountpoint,
+				Label:        part.Label,
+				Type:         part.Type,
+				UUID:         part.UUID,
+				Mountpoint:   part.Mountpoint,
+				FSTabOptions: part.FSMntOps,
+				FSTabFreq:    part.FSFreq,
+				FSTabPassNo:  part.FSPassNo,
 			},
 		})
 	}

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -74,11 +74,12 @@ type OtkGenPartitionInput struct {
 }
 
 type OtkPartOptions struct {
-	Uefi *OtkPartUEFI `json:"uefi"`
-	Bios bool         `json:"bios"`
+	UEFI *OtkPartUEFI `json:"uefi"`
+	BIOS bool         `json:"bios"`
 	// XXX: enum?
 	Type string `json:"type"`
 	Size string `json:"size"`
+	UUID string `json:"uuid"`
 
 	SectorSize uint64 `json:"sector_size"`
 }
@@ -124,25 +125,81 @@ type OtkGenPartConstOutput struct {
 }
 
 func makePartMap(pt *disk.PartitionTable) map[string]OtkPublicPartition {
+	// XXX: implement me
 	return nil
 }
 
-func run(r io.Reader) (*OtkGenPartitionsOutput, error) {
+func makePartitionTableFromOtkInput(input *OtkGenPartitionInput) (*disk.PartitionTable, error) {
+	pt := &disk.PartitionTable{
+		UUID:       input.Options.UUID,
+		Type:       input.Options.Type,
+		SectorSize: input.Options.SectorSize,
+	}
+	if input.Options.BIOS {
+		if len(pt.Partitions) > 0 {
+			panic("internal error: bios partition *must* go first")
+		}
+		pt.Partitions = append(pt.Partitions, disk.Partition{
+			Size:     1 * common.MebiByte,
+			Bootable: true,
+			Type:     disk.BIOSBootPartitionGUID,
+			UUID:     disk.BIOSBootPartitionUUID,
+		})
+	}
+	if input.Options.UEFI.Size != "" {
+		uintSize, err := common.DataSizeToUint64(input.Options.UEFI.Size)
+		if err != nil {
+			return nil, err
+		}
+		if uintSize > 0 {
+			pt.Partitions = append(pt.Partitions, disk.Partition{
+				Size: uintSize,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			})
+		}
+	}
+
+	for _, part := range input.Partitions {
+		uintSize, err := common.DataSizeToUint64(part.Size)
+		if err != nil {
+			return nil, err
+		}
+		pt.Partitions = append(pt.Partitions, disk.Partition{
+			Size: uintSize,
+			// XXX: support lvm,luks here
+			Payload: &disk.Filesystem{
+				Label:      part.Label,
+				Type:       part.Type,
+				Mountpoint: part.Mountpoint,
+			},
+		})
+	}
+
+	return pt, nil
+}
+
+func run(r io.Reader, rng *rand.Rand) (*OtkGenPartitionsOutput, error) {
 	var genPartInput OtkGenPartitionInput
 	if err := json.NewDecoder(r).Decode(&genPartInput); err != nil {
 		return nil, err
 	}
 
-	rngSeed, err := cmdutil.SeedArgFor(&buildconfig.BuildConfig{}, "", "", "")
+	basePt, err := makePartitionTableFromOtkInput(&genPartInput)
 	if err != nil {
 		return nil, err
 	}
-	source := rand.NewSource(rngSeed)
-	// math/rand is good enough in this case
-	/* #nosec G404 */
-	rng := rand.New(source)
 
-	pt, err := disk.NewPartitionTable(&basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
+	pt, err := disk.NewPartitionTable(basePt, nil, 0, disk.DefaultPartitioningMode, nil, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +219,17 @@ func run(r io.Reader) (*OtkGenPartitionsOutput, error) {
 }
 
 func main() {
-	output, err := run(os.Stdin)
+	rngSeed, err := cmdutil.SeedArgFor(&buildconfig.BuildConfig{}, "", "", "")
+	if err != nil {
+		// XXX: FIXME! helper
+		panic(err)
+	}
+	source := rand.NewSource(rngSeed)
+	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rng := rand.New(source)
+
+	output, err := run(os.Stdin, rng)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
 		os.Exit(1)

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-var expectedInput = &genpart.OtkPartInput{
-	Options: &genpart.OtkPartInputOptions{
-		UEFI: &genpart.OtkPartInputUEFI{
+var expectedInput = &genpart.Input{
+	Options: &genpart.InputOptions{
+		UEFI: &genpart.InputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
 		Type: "gpt",
 		Size: "10 GiB",
 	},
-	Partitions: []*genpart.OtkPartInputPartition{
+	Partitions: []*genpart.InputPartition{
 		{
 			Name:       "root",
 			Mountpoint: "/",
@@ -38,22 +38,22 @@ var expectedInput = &genpart.OtkPartInput{
 }
 
 func TestUnmarshalInput(t *testing.T) {
-	var otkInput genpart.OtkPartInput
+	var otkInput genpart.Input
 	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.OtkPartOutput{
-		Const: genpart.OtkPartOutputConst{
+	fakeOtkOutput := &genpart.Output{
+		Const: genpart.OutputConst{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OtkPartOutputPartition{
+			PartitionMap: map[string]genpart.OutputPartition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OtkPartOutputInternal{
+			Internal: genpart.OutputInternal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -23,7 +23,7 @@ var partInputsComplete = `
     },
     "bios": true,
     "type": "gpt",
-    "size": "10 GiB"
+    "default_size": "10 GiB"
   },
   "partitions": [
     {
@@ -54,9 +54,9 @@ var expectedInput = &genpart.Input{
 		UEFI: genpart.InputUEFI{
 			Size: "1 GiB",
 		},
-		BIOS: true,
-		Type: "gpt",
-		Size: "10 GiB",
+		BIOS:        true,
+		Type:        "gpt",
+		DefaultSize: "10 GiB",
 	},
 	Partitions: []*genpart.InputPartition{
 		{
@@ -170,7 +170,7 @@ var partInputsSimple = `
     },
     "bios": true,
     "type": "gpt",
-    "size": "10 GiB"
+    "default_size": "10 GiB"
   },
   "partitions": [
     {

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -42,6 +42,7 @@ var partInputsComplete = `
     }
   ],
   "modifications": {
+    "min_disk_size": "20 GiB",
     "partition_mode": "auto-lvm",
     "filesystems": [
       {"mountpoint": "/var/log", "minsize": 10241024}
@@ -74,6 +75,7 @@ var expectedInput = &genpart.Input{
 		},
 	},
 	Modifications: genpart.InputModifications{
+		MinDiskSize:   "20 GiB",
 		PartitionMode: disk.AutoLVMPartitioningMode,
 		Filesystems: []blueprint.FilesystemCustomization{
 			{
@@ -476,6 +478,103 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 								Type:         "xfs",
 								UUID:         "fb180daf-48a7-4ee0-b10d-394651850fd4",
 								FSTabOptions: "defaults",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 16106127360,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  16105078784,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type:        "dos",
+			DefaultSize: "15 GiB",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			MinDiskSize: "20 GiB",
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 21474836480,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  21473787904,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
 							},
 						},
 					},

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -3,17 +3,55 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	genpart "github.com/osbuild/images/cmd/otk-gen-partition-table"
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 )
 
+// see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+var partInputsComplete = `
+{
+  "options": {
+    "uefi": {
+      "size": "1 GiB"
+    },
+    "bios": true,
+    "type": "gpt",
+    "size": "10 GiB"
+  },
+  "partitions": [
+    {
+      "name": "root",
+      "mountpoint": "/",
+      "label": "root",
+      "size": "7 GiB",
+      "type": "ext4"
+    },
+    {
+      "name": "home",
+      "mountpoint": "/home",
+      "label": "home",
+      "size": "2 GiB",
+      "type": "ext4"
+    }
+  ],
+  "modifications": {
+    "partition_mode": "auto-lvm",
+    "filesystems": [
+      {"mountpoint": "/var/log", "minsize": 10241024}
+    ]
+  }
+}`
+
 var expectedInput = &genpart.Input{
-	Options: &genpart.InputOptions{
-		UEFI: &genpart.InputUEFI{
+	Options: genpart.InputOptions{
+		UEFI: genpart.InputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
@@ -35,11 +73,20 @@ var expectedInput = &genpart.Input{
 			Type:       "ext4",
 		},
 	},
+	Modifications: genpart.InputModifications{
+		PartitionMode: disk.AutoLVMPartitioningMode,
+		Filesystems: []blueprint.FilesystemCustomization{
+			{
+				Mountpoint: "/var/log",
+				MinSize:    10241024,
+			},
+		},
+	},
 }
 
 func TestUnmarshalInput(t *testing.T) {
 	var otkInput genpart.Input
-	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
+	err := json.Unmarshal([]byte(partInputsComplete), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
@@ -115,8 +162,7 @@ func TestUnmarshalOutput(t *testing.T) {
 	assert.Equal(t, expectedOutput, string(output))
 }
 
-// see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
-var simplePartOptions = `
+var partInputsSimple = `
 {
   "options": {
     "uefi": {
@@ -142,8 +188,7 @@ var simplePartOptions = `
       "type": "ext4"
     }
   ]
-}
-`
+}`
 
 // XXX: anything under "internal" we don't actually need to test
 // as we do not make any gurantees to the outside
@@ -227,12 +272,218 @@ var expectedSimplePartOutput = `{
 }
 `
 
-func TestIntegration(t *testing.T) {
+func TestIntegrationRealistic(t *testing.T) {
 	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")
 
-	inp := bytes.NewBufferString(simplePartOptions)
+	inp := bytes.NewBufferString(partInputsSimple)
 	outp := bytes.NewBuffer(nil)
 	err := genpart.Run(inp, outp)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSimplePartOutput, outp.String())
+}
+
+func TestGenPartitionTableMinimal(t *testing.T) {
+	// XXX: think about what the smalltest inputs can be and validate
+	// that it's complete and/or provide defaults (e.g. for "type" for
+	// partition and filesystem type)
+	inp := &genpart.Input{
+		Options: genpart.InputOptions{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10738466816,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
+	inp := &genpart.Input{
+		Options: genpart.InputOptions{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/boot",
+				Size:       "2 GiB",
+				Type:       "ext4",
+			},
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			Filesystems: []blueprint.FilesystemCustomization{
+				{
+					Mountpoint: "/var/log",
+					MinSize:    3 * common.GigaByte,
+				},
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"boot": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 15890120704,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  2147483648,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/boot",
+							},
+						},
+						{
+							Start: 2148532224,
+							Size:  13741588480,
+							Type:  "8e",
+							Payload: &disk.LVMVolumeGroup{
+								Name:        "rootvg",
+								Description: "created via lvm2 and osbuild",
+								LogicalVolumes: []disk.LVMLogicalVolume{
+									{
+										Name: "rootlv",
+										Size: 10737418240,
+										Payload: &disk.Filesystem{
+											Mountpoint: "/",
+											Type:       "ext4",
+											UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
+										},
+									}, {
+										Name: "var_loglv",
+										Size: 3003121664,
+										Payload: &disk.Filesystem{
+											Mountpoint: "/var/log",
+											// XXX: this is confusing
+											Type: "xfs",
+											UUID: "a178892e-e285-4ce1-9114-55780875d64e",
+											// XXX: is this needed?
+											FSTabOptions: "defaults",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// default partition mode is "auto-lvm" so LVM is created by default
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *testing.T) {
+	inp := &genpart.Input{
+		Options: genpart.InputOptions{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			// note that the extra partitin mode is used here
+			PartitionMode: disk.RawPartitioningMode,
+			Filesystems: []blueprint.FilesystemCustomization{
+				{
+					Mountpoint: "/var/log",
+					MinSize:    3 * common.GigaByte,
+				},
+			},
+		},
+	}
+	expectedOutput := &genpart.Output{
+		Const: genpart.OutputConst{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]genpart.OutputPartition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Internal: genpart.OutputInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 13739491328,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 3002073088,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Mountpoint: "/",
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							},
+						}, {
+							Start: 1048576,
+							Size:  3001024512,
+							Payload: &disk.Filesystem{
+								Mountpoint: "/var/log",
+								// XXX: this is confusing
+								Type:         "xfs",
+								UUID:         "fb180daf-48a7-4ee0-b10d-394651850fd4",
+								FSTabOptions: "defaults",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
 }

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-var expectedInput = &genpart.OtkGenPartitionInput{
-	Options: &genpart.OtkPartOptions{
-		UEFI: &genpart.OtkPartUEFI{
+var expectedInput = &genpart.OtkPartInput{
+	Options: &genpart.OtkPartInputOptions{
+		UEFI: &genpart.OtkPartInputUEFI{
 			Size: "1 GiB",
 		},
 		BIOS: true,
 		Type: "gpt",
 		Size: "10 GiB",
 	},
-	Partitions: []*genpart.OtkPartition{
+	Partitions: []*genpart.OtkPartInputPartition{
 		{
 			Name:       "root",
 			Mountpoint: "/",
@@ -38,22 +38,22 @@ var expectedInput = &genpart.OtkGenPartitionInput{
 }
 
 func TestUnmarshalInput(t *testing.T) {
-	var otkInput genpart.OtkGenPartitionInput
+	var otkInput genpart.OtkPartInput
 	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInput, &otkInput)
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.OtkGenPartitionsOutput{
-		Const: genpart.OtkGenPartConstOutput{
+	fakeOtkOutput := &genpart.OtkPartOutput{
+		Const: genpart.OtkPartOutputConst{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OtkPublicPartition{
+			PartitionMap: map[string]genpart.OtkPartOutputPartition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OtkGenPartitionsInternal{
+			Internal: genpart.OtkPartOutputInternal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{
@@ -226,68 +226,6 @@ var expectedSimplePartOutput = `{
   }
 }
 `
-
-var expectedOutput = &genpart.OtkGenPartitionsOutput{
-	Const: genpart.OtkGenPartConstOutput{
-		KernelOptsList: []string{},
-		PartitionMap: map[string]genpart.OtkPublicPartition{
-			"root": {
-				UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-			},
-		},
-		Internal: genpart.OtkGenPartitionsInternal{
-			PartitionTable: &disk.PartitionTable{
-				Size: 10740563968,
-				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-				Type: "gpt",
-				Partitions: []disk.Partition{
-					{
-						Start:    1048576,
-						Size:     1048576,
-						Type:     "21686148-6449-6E6F-744E-656564454649",
-						Bootable: true,
-						UUID:     "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
-					}, {
-						Start:    2097152,
-						Size:     1073741824,
-						Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-						Bootable: false,
-						UUID:     "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
-						Payload: &disk.Filesystem{
-							Type:         "vfat",
-							UUID:         "7B77-95E7",
-							Label:        "EFI-SYSTEM",
-							Mountpoint:   "/boot/efi",
-							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-							FSTabFreq:    0,
-							FSTabPassNo:  2,
-						},
-					}, {
-						Start: 3223322624,
-						Size:  7517224448,
-						UUID:  "a178892e-e285-4ce1-9114-55780875d64e",
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-							Label:      "root",
-							Mountpoint: "/",
-						},
-					}, {
-						Start: 1075838976,
-						Size:  2147483648,
-						UUID:  "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
-						Payload: &disk.Filesystem{
-							Type:       "ext4",
-							UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
-							Label:      "home",
-							Mountpoint: "/home",
-						},
-					},
-				},
-			},
-		},
-	},
-}
 
 func TestIntegration(t *testing.T) {
 	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,7 +81,7 @@ func TestUnmarshalOutput(t *testing.T) {
       }
     },
     "internal": {
-      "internal-partition-table": {
+      "partition-table": {
         "Size": 911,
         "UUID": "",
         "Type": "",
@@ -143,6 +142,88 @@ var simplePartOptions = `
       "type": "ext4"
     }
   ]
+}
+`
+
+// XXX: anything under "internal" we don't actually need to test
+// as we do not make any gurantees to the outside
+var expectedSimplePartOutput = `{
+  "const": {
+    "kernel_opts_list": [],
+    "partition_map": {
+      "root": {
+        "uuid": "9851898e-0b30-437d-8fad-51ec16c3697f"
+      }
+    },
+    "internal": {
+      "partition-table": {
+        "Size": 10740563968,
+        "UUID": "dbd21911-1c4e-4107-8a9f-14fe6e751358",
+        "Type": "gpt",
+        "Partitions": [
+          {
+            "Start": 1048576,
+            "Size": 1048576,
+            "Type": "21686148-6449-6E6F-744E-656564454649",
+            "Bootable": true,
+            "UUID": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+            "Payload": null
+          },
+          {
+            "Start": 2097152,
+            "Size": 1073741824,
+            "Type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+            "Bootable": false,
+            "UUID": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+            "Payload": {
+              "Type": "vfat",
+              "UUID": "7B77-95E7",
+              "Label": "EFI-SYSTEM",
+              "Mountpoint": "/boot/efi",
+              "FSTabOptions": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 2
+            }
+          },
+          {
+            "Start": 3223322624,
+            "Size": 7517224448,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "ed130be6-c822-49af-83bb-4ea648bb2264",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "9851898e-0b30-437d-8fad-51ec16c3697f",
+              "Label": "root",
+              "Mountpoint": "/",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            }
+          },
+          {
+            "Start": 1075838976,
+            "Size": 2147483648,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "9f6173fd-edc9-4dbe-9313-632af556c607",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "d8bb61b8-81cf-4c85-937b-69439a23dc5e",
+              "Label": "home",
+              "Mountpoint": "/home",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            }
+          }
+        ],
+        "SectorSize": 0,
+        "ExtraPadding": 0,
+        "StartOffset": 0
+      }
+    }
+  }
 }
 `
 
@@ -209,10 +290,11 @@ var expectedOutput = &genpart.OtkGenPartitionsOutput{
 }
 
 func TestIntegration(t *testing.T) {
-	rng := rand.New(rand.NewSource(0))
+	t.Setenv("OSBUILD_TESTING_RNG_SEED", "0")
 
-	buf := bytes.NewBufferString(simplePartOptions)
-	otkOutputs, err := genpart.Run(buf, rng)
+	inp := bytes.NewBufferString(simplePartOptions)
+	outp := bytes.NewBuffer(nil)
+	err := genpart.Run(inp, outp)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedOutput, otkOutputs)
+	assert.Equal(t, expectedSimplePartOutput, outp.String())
 }

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -17,7 +17,7 @@ import (
 // see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
 var partInputsComplete = `
 {
-  "options": {
+  "properties": {
     "uefi": {
       "size": "1 GiB"
     },
@@ -50,7 +50,7 @@ var partInputsComplete = `
 }`
 
 var expectedInput = &genpart.Input{
-	Options: genpart.InputOptions{
+	Properties: genpart.InputProperties{
 		UEFI: genpart.InputUEFI{
 			Size: "1 GiB",
 		},
@@ -164,7 +164,7 @@ func TestUnmarshalOutput(t *testing.T) {
 
 var partInputsSimple = `
 {
-  "options": {
+  "properties": {
     "uefi": {
       "size": "1 GiB"
     },
@@ -287,7 +287,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 	// that it's complete and/or provide defaults (e.g. for "type" for
 	// partition and filesystem type)
 	inp := &genpart.Input{
-		Options: genpart.InputOptions{
+		Properties: genpart.InputProperties{
 			Type: "dos",
 		},
 		Partitions: []*genpart.InputPartition{
@@ -333,7 +333,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 
 func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 	inp := &genpart.Input{
-		Options: genpart.InputOptions{
+		Properties: genpart.InputProperties{
 			Type: "dos",
 		},
 		Partitions: []*genpart.InputPartition{
@@ -424,7 +424,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 
 func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *testing.T) {
 	inp := &genpart.Input{
-		Options: genpart.InputOptions{
+		Properties: genpart.InputProperties{
 			Type: "dos",
 		},
 		Partitions: []*genpart.InputPartition{

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -1,0 +1,218 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	genpart "github.com/osbuild/images/cmd/otk-gen-partition-table"
+	"github.com/osbuild/images/pkg/disk"
+)
+
+var expectedInput = &genpart.OtkGenPartitionInput{
+	Options: &genpart.OtkPartOptions{
+		UEFI: &genpart.OtkPartUEFI{
+			Size: "1 GiB",
+		},
+		BIOS: true,
+		Type: "gpt",
+		Size: "10 GiB",
+	},
+	Partitions: []*genpart.OtkPartition{
+		{
+			Name:       "root",
+			Mountpoint: "/",
+			Label:      "root",
+			Size:       "7 GiB",
+			Type:       "ext4",
+		}, {
+			Name:       "home",
+			Mountpoint: "/home",
+			Label:      "home",
+			Size:       "2 GiB",
+			Type:       "ext4",
+		},
+	},
+}
+
+func TestUnmarshalInput(t *testing.T) {
+	var otkInput genpart.OtkGenPartitionInput
+	err := json.Unmarshal([]byte(simplePartOptions), &otkInput)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedInput, &otkInput)
+}
+
+func TestUnmarshalOutput(t *testing.T) {
+	fakeOtkOutput := &genpart.OtkGenPartitionsOutput{
+		Const: genpart.OtkGenPartConstOutput{
+			KernelOptsList: []string{"root=UUID=1234"},
+			PartitionMap: map[string]genpart.OtkPublicPartition{
+				"root": {
+					UUID: "12345",
+				},
+			},
+			Internal: genpart.OtkGenPartitionsInternal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 911,
+					Partitions: []disk.Partition{
+						{
+							UUID: "911911",
+							Payload: &disk.Filesystem{
+								Type: "ext4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// XXX: anything under "internal" we don't actually need to test
+	// as we do not make any gurantees to the outside
+	expectedOutput := `{
+  "const": {
+    "kernel_opts_list": [
+      "root=UUID=1234"
+    ],
+    "partition_map": {
+      "root": {
+        "uuid": "12345"
+      }
+    },
+    "internal": {
+      "internal-partition-table": {
+        "Size": 911,
+        "UUID": "",
+        "Type": "",
+        "Partitions": [
+          {
+            "Start": 0,
+            "Size": 0,
+            "Type": "",
+            "Bootable": false,
+            "UUID": "911911",
+            "Payload": {
+              "Type": "ext4",
+              "UUID": "",
+              "Label": "",
+              "Mountpoint": "",
+              "FSTabOptions": "",
+              "FSTabFreq": 0,
+              "FSTabPassNo": 0
+            }
+          }
+        ],
+        "SectorSize": 0,
+        "ExtraPadding": 0,
+        "StartOffset": 0
+      }
+    }
+  }
+}`
+	output, err := json.MarshalIndent(fakeOtkOutput, "", "  ")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, string(output))
+}
+
+// see https://github.com/achilleas-k/images/pull/2#issuecomment-2136025471
+var simplePartOptions = `
+{
+  "options": {
+    "uefi": {
+      "size": "1 GiB"
+    },
+    "bios": true,
+    "type": "gpt",
+    "size": "10 GiB"
+  },
+  "partitions": [
+    {
+      "name": "root",
+      "mountpoint": "/",
+      "label": "root",
+      "size": "7 GiB",
+      "type": "ext4"
+    },
+    {
+      "name": "home",
+      "mountpoint": "/home",
+      "label": "home",
+      "size": "2 GiB",
+      "type": "ext4"
+    }
+  ]
+}
+`
+
+var expectedOutput = &genpart.OtkGenPartitionsOutput{
+	Const: genpart.OtkGenPartConstOutput{
+		KernelOptsList: []string{},
+		PartitionMap: map[string]genpart.OtkPublicPartition{
+			"root": {
+				UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+			},
+		},
+		Internal: genpart.OtkGenPartitionsInternal{
+			PartitionTable: &disk.PartitionTable{
+				Size: 10740563968,
+				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type: "gpt",
+				Partitions: []disk.Partition{
+					{
+						Start:    1048576,
+						Size:     1048576,
+						Type:     "21686148-6449-6E6F-744E-656564454649",
+						Bootable: true,
+						UUID:     "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+					}, {
+						Start:    2097152,
+						Size:     1073741824,
+						Type:     "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+						Bootable: false,
+						UUID:     "68B2905B-DF3E-4FB3-80FA-49D1E773AA33",
+						Payload: &disk.Filesystem{
+							Type:         "vfat",
+							UUID:         "7B77-95E7",
+							Label:        "EFI-SYSTEM",
+							Mountpoint:   "/boot/efi",
+							FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+							FSTabFreq:    0,
+							FSTabPassNo:  2,
+						},
+					}, {
+						Start: 3223322624,
+						Size:  7517224448,
+						UUID:  "a178892e-e285-4ce1-9114-55780875d64e",
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							Label:      "root",
+							Mountpoint: "/",
+						},
+					}, {
+						Start: 1075838976,
+						Size:  2147483648,
+						UUID:  "e2d3d0d0-de6b-48f9-b44c-e85ff044c6b1",
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "fb180daf-48a7-4ee0-b10d-394651850fd4",
+							Label:      "home",
+							Mountpoint: "/home",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestIntegration(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+
+	buf := bytes.NewBufferString(simplePartOptions)
+	otkOutputs, err := genpart.Run(buf, rng)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, otkOutputs)
+}


### PR DESCRIPTION
**New command: otk-make-partition-mounts-devices**

Stub for a new otk external that consumes a Partition Table and produces
osbuild Devices and Mounts that can be attached to an osbuild Stage.

---

**osbuild: make GenMountsDevicesFromPT() public**


---

**cmd/otk-make-partition-mounts-devices: add Filename option to Input**


---

**cmd/otk-make-partition-mounts-devices: generate and print output**


---

**cmd/otk-make-partition-mounts-devices: add simple integration test**


---
