### PR TITLE
cmd/otk-*: use more shared data structures

### DIFF
--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -55,6 +55,7 @@ type InputModifications struct {
 	PartitionMode disk.PartitioningMode               `json:"partition_mode"`
 	Filesystems   []blueprint.FilesystemCustomization `json:"filesystems"`
 	MinDiskSize   string                              `json:"min_disk_size"`
+	Filename      string                              `json:"filename"`
 }
 
 type Output = otkpart.PartitionTable
@@ -181,6 +182,10 @@ func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
+	fname := "disk.img"
+	if genPartInput.Modifications.Filename != "" {
+		fname = genPartInput.Modifications.Filename
+	}
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
 	otkPart := &Output{
@@ -190,6 +195,7 @@ func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 			},
 			KernelOptsList: kernelOptions,
 			PartitionMap:   makePartMap(pt),
+			Filename:       fname,
 		},
 	}
 

--- a/cmd/otk-gen-partition-table/main.go
+++ b/cmd/otk-gen-partition-table/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/osbuild/images/internal/buildconfig"
 	"github.com/osbuild/images/internal/cmdutil"
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkpart"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
@@ -57,29 +57,10 @@ type InputModifications struct {
 	MinDiskSize   string                              `json:"min_disk_size"`
 }
 
-type Output struct {
-	Const OutputConst `json:"const"`
-}
+type Output = otkpart.PartitionTable
 
-type OutputConst struct {
-	KernelOptsList []string `json:"kernel_opts_list"`
-	// we generate this for convenience for otk users, so that they
-	// can write, e.g. "filesystem.partition_map.boot.uuid"
-	PartitionMap map[string]OutputPartition `json:"partition_map"`
-	Internal     OutputInternal             `json:"internal"`
-}
-
-// "exported" view of partitions, this is an API so only add things here
-// that are really needed and unlikely to change
-type OutputPartition struct {
-	// not a UUID type because fat UUIDs are not compliant
-	UUID string `json:"uuid"`
-}
-
-type OutputInternal = otk.PartitionInternal
-
-func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
-	pm := make(map[string]OutputPartition, len(pt.Partitions))
+func makePartMap(pt *disk.PartitionTable) map[string]otkpart.Partition {
+	pm := make(map[string]otkpart.Partition, len(pt.Partitions))
 	// TODO: think about exposing more partitions, if we do, what labels
 	// would we use? ition.Name? what about clashes with
 	// "{r,b}oot" then?
@@ -88,11 +69,11 @@ func makePartMap(pt *disk.PartitionTable) map[string]OutputPartition {
 		case *disk.Filesystem:
 			switch pl.Mountpoint {
 			case "/":
-				pm["root"] = OutputPartition{
+				pm["root"] = otkpart.Partition{
 					UUID: pl.UUID,
 				}
 			case "/boot":
-				pm["boot"] = OutputPartition{
+				pm["boot"] = otkpart.Partition{
 					UUID: pl.UUID,
 				}
 			}
@@ -203,8 +184,8 @@ func genPartitionTable(genPartInput *Input, rng *rand.Rand) (*Output, error) {
 
 	kernelOptions := osbuild.GenImageKernelOptions(pt)
 	otkPart := &Output{
-		Const: OutputConst{
-			Internal: OutputInternal{
+		Const: otkpart.Const{
+			Internal: otkpart.Internal{
 				PartitionTable: pt,
 			},
 			KernelOptsList: kernelOptions,

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -103,6 +103,7 @@ func TestUnmarshalOutput(t *testing.T) {
 					UUID: "12345",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
@@ -157,7 +158,8 @@ func TestUnmarshalOutput(t *testing.T) {
         "ExtraPadding": 0,
         "StartOffset": 0
       }
-    }
+    },
+    "filename": "disk.img"
   }
 }`
 	output, err := json.MarshalIndent(fakeOtkOutput, "", "  ")
@@ -270,7 +272,8 @@ var expectedSimplePartOutput = `{
         "ExtraPadding": 0,
         "StartOffset": 0
       }
-    }
+    },
+    "filename": "disk.img"
   }
 }
 `
@@ -309,6 +312,7 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
@@ -368,6 +372,7 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 15890120704,
@@ -456,6 +461,7 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 13739491328,
@@ -513,6 +519,7 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 16106127360,
@@ -563,6 +570,7 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
+			Filename: "disk.img",
 			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 21474836480,
@@ -572,6 +580,56 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 						{
 							Start: 1048576,
 							Size:  21473787904,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	output, err := genpart.GenPartitionTable(inp, rand.New(rand.NewSource(0)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestGenPartitionTableModificationFilename(t *testing.T) {
+	inp := &genpart.Input{
+		Properties: genpart.InputProperties{
+			Type: "dos",
+		},
+		Partitions: []*genpart.InputPartition{
+			{
+				Mountpoint: "/",
+				Size:       "10 GiB",
+				Type:       "ext4",
+			},
+		},
+		Modifications: genpart.InputModifications{
+			Filename: "custom-disk.img",
+		},
+	}
+	expectedOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
+			KernelOptsList: []string{},
+			PartitionMap: map[string]otkpart.Partition{
+				"root": {
+					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+				},
+			},
+			Filename: "custom-disk.img",
+			Internal: otkpart.Internal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10738466816,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  10737418240,
 							Payload: &disk.Filesystem{
 								Type:       "ext4",
 								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",

--- a/cmd/otk-gen-partition-table/main_test.go
+++ b/cmd/otk-gen-partition-table/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	genpart "github.com/osbuild/images/cmd/otk-gen-partition-table"
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/otkpart"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/disk"
 )
@@ -94,15 +95,15 @@ func TestUnmarshalInput(t *testing.T) {
 }
 
 func TestUnmarshalOutput(t *testing.T) {
-	fakeOtkOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	fakeOtkOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
 			KernelOptsList: []string{"root=UUID=1234"},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkpart.Partition{
 				"root": {
 					UUID: "12345",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 911,
 					Partitions: []disk.Partition{
@@ -300,15 +301,15 @@ func TestGenPartitionTableMinimal(t *testing.T) {
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkpart.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 10738466816,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -359,15 +360,15 @@ func TestGenPartitionTableCustomizationExtraMp(t *testing.T) {
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkpart.Partition{
 				"boot": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 15890120704,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -447,15 +448,15 @@ func TestGenPartitionTableCustomizationExtraMpPlusModificationPartitionMode(t *t
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkpart.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 13739491328,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -504,15 +505,15 @@ func TestGenPartitionTablePropertiesDefaultSize(t *testing.T) {
 			},
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkpart.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 16106127360,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
@@ -554,15 +555,15 @@ func TestGenPartitionTableModificationMinDiskSize(t *testing.T) {
 			MinDiskSize: "20 GiB",
 		},
 	}
-	expectedOutput := &genpart.Output{
-		Const: genpart.OutputConst{
+	expectedOutput := &otkpart.PartitionTable{
+		Const: otkpart.Const{
 			KernelOptsList: []string{},
-			PartitionMap: map[string]genpart.OutputPartition{
+			PartitionMap: map[string]otkpart.Partition{
 				"root": {
 					UUID: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
 				},
 			},
-			Internal: genpart.OutputInternal{
+			Internal: otkpart.Internal{
 				PartitionTable: &disk.PartitionTable{
 					Size: 21474836480,
 					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -6,13 +6,15 @@ import (
 	"io"
 	"os"
 
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkpart"
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
 type Input struct {
-	Filename string                `json:"filename"`
-	Internal otk.PartitionInternal `json:"internal"`
+	otkpart.PartitionTable
+
+	// XXX: move filename into gen-part-stages
+	Filename string `json:"filename"`
 }
 
 type Output struct {
@@ -27,7 +29,7 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.Internal.PartitionTable)
+	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.PartitionTable.Const.Internal.PartitionTable)
 	if err != nil {
 		return err
 	}

--- a/cmd/otk-make-partition-mounts-devices/main.go
+++ b/cmd/otk-make-partition-mounts-devices/main.go
@@ -10,12 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type Input struct {
-	otkpart.PartitionTable
-
-	// XXX: move filename into gen-part-stages
-	Filename string `json:"filename"`
-}
+type Input = otkpart.PartitionTable
 
 type Output struct {
 	RootMountName string                    `json:"root_mount_name"`
@@ -29,7 +24,7 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Filename, inp.PartitionTable.Const.Internal.PartitionTable)
+	rootMntName, mounts, devices, err := osbuild.GenMountsDevicesFromPT(inp.Const.Filename, inp.Const.Internal.PartitionTable)
 	if err != nil {
 		return err
 	}

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -62,12 +62,10 @@ const expectedOutput = `{
 func TestIntegration(t *testing.T) {
 	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	input := mkdevmnt.Input{
-		Filename: "test.disk",
-		PartitionTable: otkpart.PartitionTable{
-			Const: otkpart.Const{
-				Internal: otkpart.Internal{
-					PartitionTable: pt,
-				},
+		Const: otkpart.Const{
+			Filename: "test.disk",
+			Internal: otkpart.Internal{
+				PartitionTable: pt,
 			},
 		},
 	}

--- a/cmd/otk-make-partition-mounts-devices/main_test.go
+++ b/cmd/otk-make-partition-mounts-devices/main_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	mkdevmnt "github.com/osbuild/images/cmd/otk-make-partition-mounts-devices"
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkpart"
 	"github.com/osbuild/images/internal/testdisk"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,8 +63,12 @@ func TestIntegration(t *testing.T) {
 	pt := testdisk.MakeFakePartitionTable("/", "/boot", "/boot/efi")
 	input := mkdevmnt.Input{
 		Filename: "test.disk",
-		Internal: otk.PartitionInternal{
-			PartitionTable: pt,
+		PartitionTable: otkpart.PartitionTable{
+			Const: otkpart.Const{
+				Internal: otkpart.Internal{
+					PartitionTable: pt,
+				},
+			},
 		},
 	}
 	inpJSON, err := json.Marshal(&input)

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -8,15 +8,15 @@ import (
 
 	"github.com/osbuild/images/pkg/osbuild"
 
-	"github.com/osbuild/images/internal/otk"
+	"github.com/osbuild/images/internal/otkpart"
 )
 
 type Input struct {
-	Internal      InputInternal      `json:"internal"`
+	otkpart.PartitionTable
+
+	// XXX: move filename into gen-part-stages
 	Modifications InputModifications `json:"modifications"`
 }
-
-type InputInternal = otk.PartitionInternal
 
 type InputModifications struct {
 	Filename string `json:"filename"`
@@ -32,7 +32,7 @@ func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage
 	// rhel7 uses PTSgdisk, if we ever need to support this, make this
 	// configurable
 	partTool := osbuild.PTSfdisk
-	stages = osbuild.GenImagePrepareStages(inp.Internal.PartitionTable, filename, partTool)
+	stages = osbuild.GenImagePrepareStages(inp.PartitionTable.Const.Internal.PartitionTable, filename, partTool)
 	return stages, nil
 }
 

--- a/cmd/otk-make-partition-stages/main.go
+++ b/cmd/otk-make-partition-stages/main.go
@@ -11,16 +11,7 @@ import (
 	"github.com/osbuild/images/internal/otkpart"
 )
 
-type Input struct {
-	otkpart.PartitionTable
-
-	// XXX: move filename into gen-part-stages
-	Modifications InputModifications `json:"modifications"`
-}
-
-type InputModifications struct {
-	Filename string `json:"filename"`
-}
+type Input = otkpart.PartitionTable
 
 func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage, err error) {
 	defer func() {
@@ -32,7 +23,7 @@ func makeImagePrepareStages(inp Input, filename string) (stages []*osbuild.Stage
 	// rhel7 uses PTSgdisk, if we ever need to support this, make this
 	// configurable
 	partTool := osbuild.PTSfdisk
-	stages = osbuild.GenImagePrepareStages(inp.PartitionTable.Const.Internal.PartitionTable, filename, partTool)
+	stages = osbuild.GenImagePrepareStages(inp.Const.Internal.PartitionTable, inp.Const.Filename, partTool)
 	return stages, nil
 }
 
@@ -42,11 +33,7 @@ func run(r io.Reader, w io.Writer) error {
 		return err
 	}
 
-	fname := "disk.img"
-	if inp.Modifications.Filename != "" {
-		fname = inp.Modifications.Filename
-	}
-	stages, err := makeImagePrepareStages(inp, fname)
+	stages, err := makeImagePrepareStages(inp, inp.Const.Filename)
 	if err != nil {
 		return fmt.Errorf("cannot make partition stages: %w", err)
 	}

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	makestages "github.com/osbuild/images/cmd/otk-make-partition-stages"
+	"github.com/osbuild/images/internal/otkpart"
 	"github.com/osbuild/images/pkg/disk"
 )
 
@@ -17,19 +18,23 @@ import (
 // disk.PartitionTable so encoding it in json here will not add
 // a benefit for the test
 var minimalInputBase = makestages.Input{
-	Internal: makestages.InputInternal{
-		PartitionTable: &disk.PartitionTable{
-			Size: 10738466816,
-			UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-			Type: "dos",
-			Partitions: []disk.Partition{
-				{
-					Start: 1048576,
-					Size:  10737418240,
-					Payload: &disk.Filesystem{
-						Type:       "ext4",
-						UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-						Mountpoint: "/",
+	PartitionTable: otkpart.PartitionTable{
+		Const: otkpart.Const{
+			Internal: otkpart.Internal{
+				PartitionTable: &disk.PartitionTable{
+					Size: 10738466816,
+					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+					Type: "dos",
+					Partitions: []disk.Partition{
+						{
+							Start: 1048576,
+							Size:  10737418240,
+							Payload: &disk.Filesystem{
+								Type:       "ext4",
+								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+								Mountpoint: "/",
+							},
+						},
 					},
 				},
 			},

--- a/cmd/otk-make-partition-stages/main_test.go
+++ b/cmd/otk-make-partition-stages/main_test.go
@@ -18,22 +18,20 @@ import (
 // disk.PartitionTable so encoding it in json here will not add
 // a benefit for the test
 var minimalInputBase = makestages.Input{
-	PartitionTable: otkpart.PartitionTable{
-		Const: otkpart.Const{
-			Internal: otkpart.Internal{
-				PartitionTable: &disk.PartitionTable{
-					Size: 10738466816,
-					UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-					Type: "dos",
-					Partitions: []disk.Partition{
-						{
-							Start: 1048576,
-							Size:  10737418240,
-							Payload: &disk.Filesystem{
-								Type:       "ext4",
-								UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
-								Mountpoint: "/",
-							},
+	Const: otkpart.Const{
+		Internal: otkpart.Internal{
+			PartitionTable: &disk.PartitionTable{
+				Size: 10738466816,
+				UUID: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+				Type: "dos",
+				Partitions: []disk.Partition{
+					{
+						Start: 1048576,
+						Size:  10737418240,
+						Payload: &disk.Filesystem{
+							Type:       "ext4",
+							UUID:       "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+							Mountpoint: "/",
 						},
 					},
 				},
@@ -94,6 +92,7 @@ var minimalExpectedStages = `[
 
 func TestIntegration(t *testing.T) {
 	minimalInput := minimalInputBase
+	minimalInput.Const.Filename = "disk.img"
 	expectedStages := minimalExpectedStages
 
 	inpJSON, err := json.Marshal(&minimalInput)
@@ -109,7 +108,7 @@ func TestIntegration(t *testing.T) {
 
 func TestModificationFname(t *testing.T) {
 	input := minimalInputBase
-	input.Modifications.Filename = "mydisk.img2"
+	input.Const.Filename = "mydisk.img2"
 	expectedStages := strings.Replace(minimalExpectedStages, `"disk.img"`, `"mydisk.img2"`, -1)
 
 	inpJSON, err := json.Marshal(&input)

--- a/internal/otk/partition.go
+++ b/internal/otk/partition.go
@@ -1,9 +1,0 @@
-package otk
-
-import (
-	"github.com/osbuild/images/pkg/disk"
-)
-
-type PartitionInternal struct {
-	PartitionTable *disk.PartitionTable `json:"partition-table"`
-}

--- a/internal/otkpart/partition.go
+++ b/internal/otkpart/partition.go
@@ -14,6 +14,9 @@ type Const struct {
 	// can write, e.g. "filesystem.partition_map.boot.uuid"
 	PartitionMap map[string]Partition `json:"partition_map"`
 	Internal     Internal             `json:"internal"`
+
+	// XXX: or diskname?
+	Filename string `json:"filename"`
 }
 
 // "exported" view of partitions, this is an API so only add things here

--- a/internal/otkpart/partition.go
+++ b/internal/otkpart/partition.go
@@ -1,0 +1,28 @@
+package otkpart
+
+import (
+	"github.com/osbuild/images/pkg/disk"
+)
+
+type PartitionTable struct {
+	Const Const `json:"const"`
+}
+
+type Const struct {
+	KernelOptsList []string `json:"kernel_opts_list"`
+	// we generate this for convenience for otk users, so that they
+	// can write, e.g. "filesystem.partition_map.boot.uuid"
+	PartitionMap map[string]Partition `json:"partition_map"`
+	Internal     Internal             `json:"internal"`
+}
+
+// "exported" view of partitions, this is an API so only add things here
+// that are really needed and unlikely to change
+type Partition struct {
+	// not a UUID type because fat UUIDs are not compliant
+	UUID string `json:"uuid"`
+}
+
+type Internal struct {
+	PartitionTable *disk.PartitionTable `json:"partition-table"`
+}


### PR DESCRIPTION
otk-{gen,make}-*: move more data structures into shared
 helpers

This commit moves some more things into the new `otkpart` helper
so that all otk externals use the same data structures.

---

otk-gen-partition-table: move the "filename" customization here

The otk-make-partition-{stages,mount-devices} externals both
needed the filename modification. It seems easiest to just
define it in one place in `otk-gen-partition-table` and
then just to use the outputs from that.


